### PR TITLE
Bigrams

### DIFF
--- a/scripts/analyse_test_cases.py
+++ b/scripts/analyse_test_cases.py
@@ -16,7 +16,9 @@ yaml_path = "tests/test_addresses.yaml"
 # Prepare data
 messy_addresses, canonical_addresses = prepare_combined_test_data(yaml_path, duckdb_con)
 
-test_block = 10
+test_block = 7
+USE_BIGRAMS = True
+
 messy_addresses = messy_addresses.filter(f"test_block = {test_block}")
 canonical_addresses = canonical_addresses.filter(f"test_block = {test_block}")
 
@@ -45,8 +47,6 @@ predicted_matches = linker.inference.predict(
     experimental_optimisation=True,
 ).as_duckdbpyrelation()
 
-USE_BIGRAMS = True
-USE_TRIGRAMS = False
 
 # Improve predictions (second pass)
 improved_matches = improve_predictions_using_distinguishing_tokens(
@@ -54,7 +54,6 @@ improved_matches = improve_predictions_using_distinguishing_tokens(
     con=duckdb_con,
     match_weight_threshold=MATCH_WEIGHT_THRESHOLD_IMPROVE,
     use_bigrams=USE_BIGRAMS,
-    use_trigrams=USE_TRIGRAMS,
 )
 
 
@@ -94,18 +93,6 @@ if USE_BIGRAMS:
 
 
     bigrams_elsewhere_in_block_but_not_this
-    """
-if USE_TRIGRAMS:
-    bi_tri_cols += """
-    ,
-    overlapping_trigrams_this_l_and_r
-        .map_entries()
-        .list_filter(x -> x.value IN (1))
-        .map_from_entries()
-    AS overlapping_trigrams_this_l_and_r_count_1,
-
-
-    trigrams_elsewhere_in_block_but_not_this
     """
 
 

--- a/scripts/analyse_test_cases.py
+++ b/scripts/analyse_test_cases.py
@@ -16,7 +16,7 @@ yaml_path = "tests/test_addresses.yaml"
 # Prepare data
 messy_addresses, canonical_addresses = prepare_combined_test_data(yaml_path, duckdb_con)
 
-test_block = 7
+test_block = 10
 messy_addresses = messy_addresses.filter(f"test_block = {test_block}")
 canonical_addresses = canonical_addresses.filter(f"test_block = {test_block}")
 
@@ -45,14 +45,25 @@ predicted_matches = linker.inference.predict(
     experimental_optimisation=True,
 ).as_duckdbpyrelation()
 
+USE_BIGRAMS = True
+USE_TRIGRAMS = False
 
 # Improve predictions (second pass)
 improved_matches = improve_predictions_using_distinguishing_tokens(
     df_predict=predicted_matches,
     con=duckdb_con,
     match_weight_threshold=MATCH_WEIGHT_THRESHOLD_IMPROVE,
+    use_bigrams=USE_BIGRAMS,
+    use_trigrams=USE_TRIGRAMS,
 )
 
+
+sql = """
+select distinct concat_ws(' ', original_address_concat_r, postcode_r) as messy_address
+from improved_matches
+"""
+
+duckdb_con.sql(sql).show(max_width=700)
 
 # Is best mrach true match?
 
@@ -71,18 +82,50 @@ and p.unique_id_l = b.unique_id_l
 """
 best_match_id, messy_id, true_match_id = duckdb_con.sql(sql).fetchone()
 
+bi_tri_cols = ""
+if USE_BIGRAMS:
+    bi_tri_cols += """
+    ,
+    overlapping_bigrams_this_l_and_r
+        .map_entries()
+        .list_filter(x -> x.value IN (1))
+        .map_from_entries()
+    AS overlapping_bigrams_this_l_and_r_count_1,
+
+
+    bigrams_elsewhere_in_block_but_not_this
+    """
+if USE_TRIGRAMS:
+    bi_tri_cols += """
+    ,
+    overlapping_trigrams_this_l_and_r
+        .map_entries()
+        .list_filter(x -> x.value IN (1))
+        .map_from_entries()
+    AS overlapping_trigrams_this_l_and_r_count_1,
+
+
+    trigrams_elsewhere_in_block_but_not_this
+    """
+
 
 sql = f"""
 select
 match_weight,
-original_address_concat_l,
+match_weight_original,
+mw_adjustment,
+original_address_concat_l as canonical_address,
 case
 when unique_id_l = '{true_match_id}' then '✅'
 else ''
 end as true_match,
-original_address_concat_r,
-overlapping_tokens_this_l_and_r ,
-tokens_elsewhere_in_block_but_not_this ,
+overlapping_tokens_this_l_and_r
+    .map_entries()
+    .list_filter(x -> x.value IN (1))
+    .map_from_entries()
+AS overlapping_tokens_this_l_and_r_count_1,
+tokens_elsewhere_in_block_but_not_this
+{bi_tri_cols},
 missing_tokens
 from improved_matches
 order by match_weight desc

--- a/scripts/analyse_test_cases.py
+++ b/scripts/analyse_test_cases.py
@@ -16,7 +16,7 @@ yaml_path = "tests/test_addresses.yaml"
 # Prepare data
 messy_addresses, canonical_addresses = prepare_combined_test_data(yaml_path, duckdb_con)
 
-test_block = 6
+test_block = 7
 messy_addresses = messy_addresses.filter(f"test_block = {test_block}")
 canonical_addresses = canonical_addresses.filter(f"test_block = {test_block}")
 

--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -133,7 +133,8 @@ def evaluate_matching_results(matching_results, duckdb_con):
         t.match_weight - r.match_weight AS score_diff_from_top,
         CASE WHEN r.unique_id_l = r.true_match_id THEN 1 ELSE 0 END AS is_correct_match
     FROM results r
-    JOIN top_matches_in_window t ON r.unique_id_r = t.test_block_id;
+    JOIN top_matches_in_window t ON r.unique_id_r = t.test_block_id
+    order by test_block_id, r.match_weight desc;
     """
     # duckdb_con.sql(sql).show(max_width=50000)
 
@@ -241,7 +242,7 @@ def evaluate_matching_results(matching_results, duckdb_con):
             SELECT * FROM messy_record
             UNION ALL SELECT * FROM true_match
             UNION ALL SELECT * FROM false_match
-            ORDER BY record_type
+
             """
 
             details = duckdb_con.execute(mismatch_query).fetchall()

--- a/tests/test_addresses.yaml
+++ b/tests/test_addresses.yaml
@@ -84,3 +84,13 @@ addresses:
     canonical_addresses:
       - ["OLD FARM COTTAGE BADGERCROFT ROAD PIKING", "ZZ1 0ZZ"]
       - ["PAD FARM HOUSE BADGERCROFT ROAD PIKING", "ZZ1 0ZZ"]
+
+  # Based on EPC id 541046809962
+  # Note this only fails because it's flat A basement, if it were flat b basement
+  # it would be fine
+  - messy_address: ["144 & A HALF PIPER ROAD LONDON", "W14 0AA"]
+    canonical_addresses:
+      - ["144 AND A HALF PIPER ROAD LONDON", "W14 0AA"]
+      - ["FLAT A BASEMENT 144 AND A HALF PIPER ROAD LONDON", "W14 0AA"]
+      - ["FLAT B 144 AND A HALF PIPER ROAD LONDON", "W14 0AA"]
+      - ["FLAT D 144 AND A HALF PIPER ROAD LONDON", "W14 0AA"]

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -7,6 +7,8 @@ def improve_predictions_using_distinguishing_tokens(
     con: DuckDBPyConnection,
     match_weight_threshold: float = -20,
     top_n_matches: int = 5,
+    use_bigrams: bool = True,
+    use_trigrams: bool = True,
 ):
     """
     Improve match predictions by identifying distinguishing tokens between addresses.
@@ -16,199 +18,216 @@ def improve_predictions_using_distinguishing_tokens(
         con: DuckDB connection
         match_weight_threshold: Minimum match weight to consider
         top_n_matches: Number of top matches to consider for each unique_id_r
+        use_bigrams: Whether to use bigram analysis in matching
+        use_trigrams: Whether to use trigram analysis in matching
 
     Returns:
         DuckDBPyRelation: Table with improved match predictions
     """
-    cols = """
-        match_weight,
-        match_probability,
-        source_dataset_l,
-        unique_id_l,
-        source_dataset_r,
-        unique_id_r,
-        original_address_concat_l,
-        original_address_concat_r,
-        postcode_l,
-        postcode_r,
-    """
+    # Define template strings for n-gram operations
 
-    # Create a table with tokenized addresses
-    sql_token_and_bigrams = f"""
+    # Template for creating n-grams from a token list
+    ngram_template = """
+    -- Create {gram_type} from {token_list}
+    list_transform(
+        list_zip(
+            {zip_parts}
+        ),
+        tup -> {concat_parts}
+    ) AS {output_name}"""
 
-    WITH good_matches AS (
-        SELECT *
-        FROM df_predict
-        WHERE match_weight > {match_weight_threshold}
-    ),
-    top_n_matches AS (
-        SELECT *
-        FROM good_matches
-        QUALIFY ROW_NUMBER() OVER (
-            PARTITION BY unique_id_r
-            ORDER BY match_weight DESC
-        ) <= {top_n_matches}  -- e.g., 5 for top 5 matches
-    ),
-    tokenise_r AS (
-        SELECT DISTINCT
-            unique_id_r,
+    # Function to generate n-gram creation SQL
+    def generate_ngram_sql(gram_type, token_list, output_name):
+        n = 1
+        if gram_type == "bigrams":
+            n = 2
+        elif gram_type == "trigrams":
+            n = 3
 
-            original_address_concat_r
-                .trim()
-                .upper()
-                .regexp_split_to_array('\\s+')
-                .list_filter(tok -> tok NOT IN ('FLAT'))
-                as tokens_r
-        FROM top_n_matches
-    ),
-    tokens as (
-        select
-        t.unique_id_r,
-        t.tokens_r,
+        zip_parts = []
+        concat_parts = []
 
-        -----------------
-        -- TOKENS SECTION
-        -----------------
+        for i in range(1, n + 1):
+            zip_parts.append(
+                f"list_slice({token_list}, {i}, length({token_list}) - {n - i})"
+            )
 
+        concat_parts_str = "concat_ws(' '"
+        for i in range(1, n + 1):
+            concat_parts_str += f", tup[{i}]"
+        concat_parts_str += ")"
+
+        return ngram_template.format(
+            gram_type=gram_type,
+            token_list=token_list,
+            zip_parts=",\n                ".join(zip_parts),
+            concat_parts=concat_parts_str,
+            output_name=output_name,
+        )
+
+    # Template for histogram overlapping calculations
+    histogram_overlap_template = """
+    -- Filter to only include {gram_type} that appear in both r and the block
+    map_from_entries(
+        list_filter(
+            map_entries(hist_all_{gram_type}_in_block_l),
+            x -> list_contains({gram_type}_r, x.key)
+        )
+    ) AS hist_overlapping_{gram_type}_r_block_l"""
+
+    # Template for filtering to items not in another list
+    not_in_list_template = """
+    -- {gram_type} in r but not in this l
+    list_filter({source_list}, item -> item NOT IN {filter_list}) as {output_name}"""
+
+    # Template for creating map from entries that overlap
+    overlap_map_template = """
+    -- Filter to only include {gram_type} that appear in both this l and r
+    map_from_entries(
+        list_filter(
+            map_entries(hist_overlapping_{gram_type}_r_block_l),
+            x -> list_contains({gram_type}_l, x.key)
+        )
+    ) AS overlapping_{gram_type}_this_l_and_r"""
+
+    # Template for items that appear elsewhere but not in this item
+    elsewhere_but_not_here_template = """
+    -- {gram_type} that appear elsewhere in the block but not in this l
+    map_from_entries(
+        list_filter(
+            map_entries(hist_all_{gram_type}_in_block_l),
+            x -> list_contains({gram_type}_r_not_in_l, x.key)
+        )
+    ) AS {gram_type}_elsewhere_in_block_but_not_this"""
+
+    # Template for the adjustment formula in the final SQL
+    adjustment_template = """ifnull(map_values(overlapping_{gram_type}_this_l_and_r)
+        .list_transform(x -> 1/(x^2))
+        .list_sum() * {reward_multiplier}, 0)
+    - map_values({gram_type}_elsewhere_in_block_but_not_this)
+        .length() * {punishment_multiplier}"""
+
+    # Token section is always included
+    tokens_section_cte = f"""
         flatten(array_agg((regexp_split_to_array(upper(trim(original_address_concat_l)), '\\s+')))) as tokens_in_block_l,
 
         -- Counts of tokens in canonical addresses within block
         list_aggregate(tokens_in_block_l, 'histogram') AS hist_all_tokens_in_block_l,
 
-        -- Filter to only include tokens that appear in both r and the block
-        map_from_entries(
-                list_filter(
-                    map_entries(hist_all_tokens_in_block_l),
-                    x -> list_contains(tokens_r, x.key)
-                )
-            ) AS hist_overlapping_tokens_r_block_l,
+        {histogram_overlap_template.format(gram_type="tokens")}"""
 
-        -----------------
-        -- BIGRAMS SECTION
-        -----------------
+    # Prepare parts of the SQL that depend on use_bigrams and use_trigrams
+    tokens_cte_parts = [tokens_section_cte]
 
+    if use_bigrams:
+        bigram_section_tokens = f"""
         -- Create bigrams from all tokens in block
-        list_transform(
-            list_zip(
-                list_slice(tokens_in_block_l, 1, length(tokens_in_block_l) - 1),
-                list_slice(tokens_in_block_l, 2, length(tokens_in_block_l))
-            ),
-            tup -> concat_ws(' ', tup[1], tup[2])
-        ) AS bigrams_in_block_l,
+        {generate_ngram_sql("bigrams", "tokens_in_block_l", "bigrams_in_block_l")},
 
         -- Counts of bigrams in canonical addresses within block
         list_aggregate(bigrams_in_block_l, 'histogram') AS hist_all_bigrams_in_block_l,
 
         -- Create bigrams from tokens_r
-        list_transform(
-            list_zip(
-                list_slice(tokens_r, 1, length(tokens_r) - 1),
-                list_slice(tokens_r, 2, length(tokens_r))
-            ),
-            tup -> concat_ws(' ', tup[1], tup[2])
-        ) AS bigrams_r,
+        {generate_ngram_sql("bigrams", "tokens_r", "bigrams_r")},
 
-        -- Filter to only include bigrams that appear in both r and the block
-        map_from_entries(
-            list_filter(
-                map_entries(hist_all_bigrams_in_block_l),
-                x -> list_contains(bigrams_r, x.key)
-            )
-        ) AS hist_overlapping_bigrams_r_block_l
+        {histogram_overlap_template.format(gram_type="bigrams")}"""
+        tokens_cte_parts.append(bigram_section_tokens)
 
-        from top_n_matches m
-        join tokenise_r t using (unique_id_r)
-        group by t.unique_id_r, t.tokens_r
-    ),
-    intermediate AS (
-        SELECT
-            match_weight,
-            match_probability,
-            unique_id_l,
-            m.unique_id_r,
-            original_address_concat_l,
-            original_address_concat_r,
+    if use_trigrams:
+        trigram_section_tokens = f"""
+        -- Create trigrams from all tokens in block
+        {generate_ngram_sql("trigrams", "tokens_in_block_l", "trigrams_in_block_l")},
 
-            -----------------
-            -- TOKENS SECTION
-            -----------------
+        -- Counts of trigrams in canonical addresses within block
+        list_aggregate(trigrams_in_block_l, 'histogram') AS hist_all_trigrams_in_block_l,
 
+        -- Create trigrams from tokens_r
+        {generate_ngram_sql("trigrams", "tokens_r", "trigrams_r")},
+
+        {histogram_overlap_template.format(gram_type="trigrams")}"""
+        tokens_cte_parts.append(trigram_section_tokens)
+
+    # Token section for intermediate CTE is always included
+    intermediate_cte_parts = [
+        f"""
             original_address_concat_l
                 .trim()
                 .upper()
                 .regexp_split_to_array('\\s+')
-                .list_filter(tok -> tok NOT IN ('FLAT'))
                 AS tokens_l,
             t.tokens_r,
 
-            -- Filter out any tokens not in l block!
-            map_from_entries(
-                list_filter(
-                    map_entries(hist_overlapping_tokens_r_block_l),
-                    x -> list_contains(tokens_l, x.key)
-                )
-            ) AS overlapping_tokens_this_l_and_r,
+            {overlap_map_template.format(gram_type="tokens")},
 
             t.hist_all_tokens_in_block_l,
             t.hist_overlapping_tokens_r_block_l,
 
-            list_filter(t.tokens_r, tok -> tok NOT IN tokens_l) as tokens_r_not_in_l,
+            {
+            not_in_list_template.format(
+                gram_type="Tokens",
+                source_list="t.tokens_r",
+                filter_list="tokens_l",
+                output_name="tokens_r_not_in_l",
+            )
+        },
 
-            map_from_entries(
-                list_filter(
-                    map_entries(hist_all_tokens_in_block_l),
-                    x -> list_contains(tokens_r_not_in_l, x.key)
-                )
-            ) AS tokens_elsewhere_in_block_but_not_this,
+            {elsewhere_but_not_here_template.format(gram_type="tokens")},
 
             -- missing tokens are tokens in the canonical address but not in the messy address
-            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens,
+            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens"""
+    ]
 
-            -----------------
-            -- BIGRAMS SECTION
-            -----------------
-
+    if use_bigrams:
+        bigram_section_intermediate = f"""
             -- Create bigrams from tokens_l
-            list_transform(
-                list_zip(
-                    list_slice((tokens_l), 1,
-                              length((tokens_l)) - 1),
-                    list_slice((tokens_l), 2,
-                              length((tokens_l)))
-                ),
-                tup -> concat_ws(' ', tup[1], tup[2])
-            ) AS bigrams_l,
+            {generate_ngram_sql("bigrams", "(tokens_l)", "bigrams_l")},
 
             t.bigrams_r,
 
-            -- Filter to only include bigrams that appear in both this l and r
-            map_from_entries(
-                list_filter(
-                    map_entries(hist_overlapping_bigrams_r_block_l),
-                    x -> list_contains(bigrams_l, x.key)
-                )
-            ) AS overlapping_bigrams_this_l_and_r,
+            {overlap_map_template.format(gram_type="bigrams")},
 
             t.hist_all_bigrams_in_block_l,
             t.hist_overlapping_bigrams_r_block_l,
 
-            -- Bigrams in r but not in this l
-            list_filter(t.bigrams_r, bg -> bg NOT IN bigrams_l) as bigrams_r_not_in_l,
+            {
+            not_in_list_template.format(
+                gram_type="Bigrams",
+                source_list="t.bigrams_r",
+                filter_list="bigrams_l",
+                output_name="bigrams_r_not_in_l",
+            )
+        },
 
-            -- Bigrams that appear elsewhere in the block but not in this l
-            map_from_entries(
-                list_filter(
-                    map_entries(hist_all_bigrams_in_block_l),
-                    x -> list_contains(bigrams_r_not_in_l, x.key)
-                )
-            ) AS bigrams_elsewhere_in_block_but_not_this,
+            {elsewhere_but_not_here_template.format(gram_type="bigrams")}"""
+        intermediate_cte_parts.append(bigram_section_intermediate)
 
-            postcode_l,
-            postcode_r
-        FROM top_n_matches m
-        left join tokens t using (unique_id_r)
-    )
-    SELECT
+    if use_trigrams:
+        trigram_section_intermediate = f"""
+            -- Create trigrams from tokens_l
+            {generate_ngram_sql("trigrams", "(tokens_l)", "trigrams_l")},
+
+            t.trigrams_r,
+
+            {overlap_map_template.format(gram_type="trigrams")},
+
+            t.hist_all_trigrams_in_block_l,
+            t.hist_overlapping_trigrams_r_block_l,
+
+            {
+            not_in_list_template.format(
+                gram_type="Trigrams",
+                source_list="t.trigrams_r",
+                filter_list="trigrams_l",
+                output_name="trigrams_r_not_in_l",
+            )
+        },
+
+            {elsewhere_but_not_here_template.format(gram_type="trigrams")}"""
+        intermediate_cte_parts.append(trigram_section_intermediate)
+
+    # Fields for the final SELECT statement
+    select_fields_parts = [
+        """
         unique_id_l,
         unique_id_r,
         match_weight,
@@ -226,8 +245,11 @@ def improve_predictions_using_distinguishing_tokens(
         tokens_elsewhere_in_block_but_not_this,
         hist_overlapping_tokens_r_block_l,
         hist_all_tokens_in_block_l,
-        missing_tokens,
+        missing_tokens"""
+    ]
 
+    if use_bigrams:
+        bigram_fields = """
         -----------------
         -- BIGRAMS SECTION
         -----------------
@@ -235,65 +257,193 @@ def improve_predictions_using_distinguishing_tokens(
         overlapping_bigrams_this_l_and_r,
         bigrams_elsewhere_in_block_but_not_this,
         hist_overlapping_bigrams_r_block_l,
-        hist_all_bigrams_in_block_l
+        hist_all_bigrams_in_block_l"""
+        select_fields_parts.append(bigram_fields)
 
+    if use_trigrams:
+        trigram_fields = """
+        -----------------
+        -- TRIGRAMS SECTION
+        -----------------
+
+        overlapping_trigrams_this_l_and_r,
+        trigrams_elsewhere_in_block_but_not_this,
+        hist_overlapping_trigrams_r_block_l,
+        hist_all_trigrams_in_block_l"""
+        select_fields_parts.append(trigram_fields)
+
+    # Join parts with proper separators to build the SQL
+    tokens_cte = ",\n".join(tokens_cte_parts)
+    intermediate_cte = ",\n".join(intermediate_cte_parts)
+    select_fields = ",".join(select_fields_parts)
+
+    # SQL for tokenizing and creating n-grams
+    sql_token_and_ngrams = f"""
+    WITH good_matches AS (
+        SELECT *
+        FROM df_predict
+        WHERE match_weight > {match_weight_threshold}
+    ),
+    top_n_matches AS (
+        SELECT *
+        FROM good_matches
+        QUALIFY ROW_NUMBER() OVER (
+            PARTITION BY unique_id_r
+            ORDER BY match_weight DESC
+        ) <= {top_n_matches}  -- e.g., 5 for top 5 matches
+    ),
+    tokenise_r AS (
+        SELECT DISTINCT
+            unique_id_r,
+            original_address_concat_r
+                .trim()
+                .upper()
+                .regexp_split_to_array('\\s+')
+                -- .list_filter(tok -> tok NOT IN ('FLAT'))
+                as tokens_r
+        FROM top_n_matches
+    ),
+    tokens as (
+        select
+        t.unique_id_r,
+        t.tokens_r,
+
+        -----------------
+        -- TOKENS SECTION
+        -----------------
+{tokens_cte}
+
+        from top_n_matches m
+        join tokenise_r t using (unique_id_r)
+        group by t.unique_id_r, t.tokens_r
+    ),
+    intermediate AS (
+        SELECT
+            match_weight,
+            match_probability,
+            unique_id_l,
+            m.unique_id_r,
+            original_address_concat_l,
+            original_address_concat_r,
+
+            -----------------
+            -- TOKENS SECTION
+            -----------------
+{intermediate_cte},
+            postcode_l,
+            postcode_r
+        FROM top_n_matches m
+        left join tokens t using (unique_id_r)
+    )
+    SELECT{select_fields}
     FROM intermediate
     ORDER BY unique_id_r;
     """
+    # print(sql_token_and_ngrams)
 
-    windowed_tokens = con.sql(sql_token_and_bigrams)
+    windowed_tokens = con.sql(sql_token_and_ngrams)
 
-    # Calculate new match weights based on distinguishing tokens and bigrams
+    # Define multipliers for each n-gram type
+    overall_reward_multiplier = 1.5
+    REWARD_MULTIPLIER = 2 * overall_reward_multiplier
+    PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
+    BIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
+    BIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
+    TRIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
+    TRIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
 
-    REWARD_MULTIPLIER = 2
-    PUNISHMENT_MULTIPLIER = 2
-    BIGRAM_REWARD_MULTIPLIER = 3
-    BIGRAM_PUNISHMENT_MULTIPLIER = 3
+    # Base adjustment for tokens (always included)
+    adjustment_parts = [
+        f"""
+        -- Token-based adjustments
+        {
+            adjustment_template.format(
+                gram_type="tokens",
+                reward_multiplier=REWARD_MULTIPLIER,
+                punishment_multiplier=PUNISHMENT_MULTIPLIER,
+            )
+        }
+        - (0.1 * len(missing_tokens))"""
+    ]
+
+    # Add bigram adjustment if enabled
+    if use_bigrams:
+        bigram_adjustment = f"""
+        -- Bigram-based adjustments
+        + {
+            adjustment_template.format(
+                gram_type="bigrams",
+                reward_multiplier=BIGRAM_REWARD_MULTIPLIER,
+                punishment_multiplier=BIGRAM_PUNISHMENT_MULTIPLIER,
+            )
+        }"""
+        adjustment_parts.append(bigram_adjustment)
+
+    # Add trigram adjustment if enabled
+    if use_trigrams:
+        trigram_adjustment = f"""
+        -- Trigram-based adjustments
+        + {
+            adjustment_template.format(
+                gram_type="trigrams",
+                reward_multiplier=TRIGRAM_REWARD_MULTIPLIER,
+                punishment_multiplier=TRIGRAM_PUNISHMENT_MULTIPLIER,
+            )
+        }"""
+        adjustment_parts.append(trigram_adjustment)
+
+    # Join adjustment parts
+    adjustment_expr = "\n".join(adjustment_parts)
+
+    # Output fields for final SELECT
+    output_fields_parts = [
+        """
+        -- Token-related fields
+        overlapping_tokens_this_l_and_r,
+        tokens_elsewhere_in_block_but_not_this,
+        missing_tokens"""
+    ]
+
+    if use_bigrams:
+        output_fields_parts.append("""
+        -- Bigram-related fields
+        overlapping_bigrams_this_l_and_r,
+        bigrams_elsewhere_in_block_but_not_this""")
+
+    if use_trigrams:
+        output_fields_parts.append("""
+        -- Trigram-related fields
+        overlapping_trigrams_this_l_and_r,
+        trigrams_elsewhere_in_block_but_not_this""")
+
+    output_fields_parts.append("""
+        original_address_concat_l,
+        postcode_l,
+        original_address_concat_r,
+        postcode_r""")
+
+    output_fields = ",".join(output_fields_parts)
+
+    # Calculate new match weights based on distinguishing tokens, bigrams and trigrams
     sql = f"""
     CREATE OR REPLACE TABLE matches AS
 
     SELECT
         unique_id_r,
         unique_id_l,
-
-        -- Token-based adjustments
-        map_values(overlapping_tokens_this_l_and_r)
-            .list_transform(x -> 1/(x^2))
-            .list_sum() *  {REWARD_MULTIPLIER}
-        - map_values(tokens_elsewhere_in_block_but_not_this)
-            .length() * {PUNISHMENT_MULTIPLIER}
-        - (0.1 * len(missing_tokens))
-
-        -- Bigram-based adjustments
-        + map_values(overlapping_bigrams_this_l_and_r)
-            .list_transform(x -> 1/(x^2))
-            .list_sum() * {BIGRAM_REWARD_MULTIPLIER}
-        - map_values(bigrams_elsewhere_in_block_but_not_this)
-            .length() * {BIGRAM_PUNISHMENT_MULTIPLIER}
+        {adjustment_expr}
         as mw_adjustment,
 
         match_weight AS match_weight_original,
         match_probability AS match_probability_original,
         (match_weight_original + mw_adjustment) AS match_weight,
         pow(2, match_weight)/(1+pow(2, match_weight)) AS match_probability,
-
-        -- Token-related fields
-        overlapping_tokens_this_l_and_r,
-        tokens_elsewhere_in_block_but_not_this,
-        missing_tokens,
-
-        -- Bigram-related fields
-        overlapping_bigrams_this_l_and_r,
-        bigrams_elsewhere_in_block_but_not_this,
-
-        original_address_concat_l,
-        postcode_l,
-        original_address_concat_r,
-        postcode_r
+        {output_fields}
 
     FROM windowed_tokens
     """
 
     con.execute(sql)
+
     matches = con.table("matches")
     return matches

--- a/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
+++ b/uk_address_matcher/post_linkage/identify_distinguishing_tokens.py
@@ -7,8 +7,6 @@ def improve_predictions_using_distinguishing_tokens(
     con: DuckDBPyConnection,
     match_weight_threshold: float = -20,
     top_n_matches: int = 5,
-    use_bigrams: bool = True,
-    use_trigrams: bool = True,
 ):
     """
     Improve match predictions by identifying distinguishing tokens between addresses.
@@ -18,267 +16,26 @@ def improve_predictions_using_distinguishing_tokens(
         con: DuckDB connection
         match_weight_threshold: Minimum match weight to consider
         top_n_matches: Number of top matches to consider for each unique_id_r
-        use_bigrams: Whether to use bigram analysis in matching
-        use_trigrams: Whether to use trigram analysis in matching
 
     Returns:
         DuckDBPyRelation: Table with improved match predictions
     """
-    # Define template strings for n-gram operations
-
-    # Template for creating n-grams from a token list
-    ngram_template = """
-    -- Create {gram_type} from {token_list}
-    list_transform(
-        list_zip(
-            {zip_parts}
-        ),
-        tup -> {concat_parts}
-    ) AS {output_name}"""
-
-    # Function to generate n-gram creation SQL
-    def generate_ngram_sql(gram_type, token_list, output_name):
-        n = 1
-        if gram_type == "bigrams":
-            n = 2
-        elif gram_type == "trigrams":
-            n = 3
-
-        zip_parts = []
-        concat_parts = []
-
-        for i in range(1, n + 1):
-            zip_parts.append(
-                f"list_slice({token_list}, {i}, length({token_list}) - {n - i})"
-            )
-
-        concat_parts_str = "concat_ws(' '"
-        for i in range(1, n + 1):
-            concat_parts_str += f", tup[{i}]"
-        concat_parts_str += ")"
-
-        return ngram_template.format(
-            gram_type=gram_type,
-            token_list=token_list,
-            zip_parts=",\n                ".join(zip_parts),
-            concat_parts=concat_parts_str,
-            output_name=output_name,
-        )
-
-    # Template for histogram overlapping calculations
-    histogram_overlap_template = """
-    -- Filter to only include {gram_type} that appear in both r and the block
-    map_from_entries(
-        list_filter(
-            map_entries(hist_all_{gram_type}_in_block_l),
-            x -> list_contains({gram_type}_r, x.key)
-        )
-    ) AS hist_overlapping_{gram_type}_r_block_l"""
-
-    # Template for filtering to items not in another list
-    not_in_list_template = """
-    -- {gram_type} in r but not in this l
-    list_filter({source_list}, item -> item NOT IN {filter_list}) as {output_name}"""
-
-    # Template for creating map from entries that overlap
-    overlap_map_template = """
-    -- Filter to only include {gram_type} that appear in both this l and r
-    map_from_entries(
-        list_filter(
-            map_entries(hist_overlapping_{gram_type}_r_block_l),
-            x -> list_contains({gram_type}_l, x.key)
-        )
-    ) AS overlapping_{gram_type}_this_l_and_r"""
-
-    # Template for items that appear elsewhere but not in this item
-    elsewhere_but_not_here_template = """
-    -- {gram_type} that appear elsewhere in the block but not in this l
-    map_from_entries(
-        list_filter(
-            map_entries(hist_all_{gram_type}_in_block_l),
-            x -> list_contains({gram_type}_r_not_in_l, x.key)
-        )
-    ) AS {gram_type}_elsewhere_in_block_but_not_this"""
-
-    # Template for the adjustment formula in the final SQL
-    adjustment_template = """ifnull(map_values(overlapping_{gram_type}_this_l_and_r)
-        .list_transform(x -> 1/(x^2))
-        .list_sum() * {reward_multiplier}, 0)
-    - map_values({gram_type}_elsewhere_in_block_but_not_this)
-        .length() * {punishment_multiplier}"""
-
-    # Token section is always included
-    tokens_section_cte = f"""
-        flatten(array_agg((regexp_split_to_array(upper(trim(original_address_concat_l)), '\\s+')))) as tokens_in_block_l,
-
-        -- Counts of tokens in canonical addresses within block
-        list_aggregate(tokens_in_block_l, 'histogram') AS hist_all_tokens_in_block_l,
-
-        {histogram_overlap_template.format(gram_type="tokens")}"""
-
-    # Prepare parts of the SQL that depend on use_bigrams and use_trigrams
-    tokens_cte_parts = [tokens_section_cte]
-
-    if use_bigrams:
-        bigram_section_tokens = f"""
-        -- Create bigrams from all tokens in block
-        {generate_ngram_sql("bigrams", "tokens_in_block_l", "bigrams_in_block_l")},
-
-        -- Counts of bigrams in canonical addresses within block
-        list_aggregate(bigrams_in_block_l, 'histogram') AS hist_all_bigrams_in_block_l,
-
-        -- Create bigrams from tokens_r
-        {generate_ngram_sql("bigrams", "tokens_r", "bigrams_r")},
-
-        {histogram_overlap_template.format(gram_type="bigrams")}"""
-        tokens_cte_parts.append(bigram_section_tokens)
-
-    if use_trigrams:
-        trigram_section_tokens = f"""
-        -- Create trigrams from all tokens in block
-        {generate_ngram_sql("trigrams", "tokens_in_block_l", "trigrams_in_block_l")},
-
-        -- Counts of trigrams in canonical addresses within block
-        list_aggregate(trigrams_in_block_l, 'histogram') AS hist_all_trigrams_in_block_l,
-
-        -- Create trigrams from tokens_r
-        {generate_ngram_sql("trigrams", "tokens_r", "trigrams_r")},
-
-        {histogram_overlap_template.format(gram_type="trigrams")}"""
-        tokens_cte_parts.append(trigram_section_tokens)
-
-    # Token section for intermediate CTE is always included
-    intermediate_cte_parts = [
-        f"""
-            original_address_concat_l
-                .trim()
-                .upper()
-                .regexp_split_to_array('\\s+')
-                AS tokens_l,
-            t.tokens_r,
-
-            {overlap_map_template.format(gram_type="tokens")},
-
-            t.hist_all_tokens_in_block_l,
-            t.hist_overlapping_tokens_r_block_l,
-
-            {
-            not_in_list_template.format(
-                gram_type="Tokens",
-                source_list="t.tokens_r",
-                filter_list="tokens_l",
-                output_name="tokens_r_not_in_l",
-            )
-        },
-
-            {elsewhere_but_not_here_template.format(gram_type="tokens")},
-
-            -- missing tokens are tokens in the canonical address but not in the messy address
-            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens"""
-    ]
-
-    if use_bigrams:
-        bigram_section_intermediate = f"""
-            -- Create bigrams from tokens_l
-            {generate_ngram_sql("bigrams", "(tokens_l)", "bigrams_l")},
-
-            t.bigrams_r,
-
-            {overlap_map_template.format(gram_type="bigrams")},
-
-            t.hist_all_bigrams_in_block_l,
-            t.hist_overlapping_bigrams_r_block_l,
-
-            {
-            not_in_list_template.format(
-                gram_type="Bigrams",
-                source_list="t.bigrams_r",
-                filter_list="bigrams_l",
-                output_name="bigrams_r_not_in_l",
-            )
-        },
-
-            {elsewhere_but_not_here_template.format(gram_type="bigrams")}"""
-        intermediate_cte_parts.append(bigram_section_intermediate)
-
-    if use_trigrams:
-        trigram_section_intermediate = f"""
-            -- Create trigrams from tokens_l
-            {generate_ngram_sql("trigrams", "(tokens_l)", "trigrams_l")},
-
-            t.trigrams_r,
-
-            {overlap_map_template.format(gram_type="trigrams")},
-
-            t.hist_all_trigrams_in_block_l,
-            t.hist_overlapping_trigrams_r_block_l,
-
-            {
-            not_in_list_template.format(
-                gram_type="Trigrams",
-                source_list="t.trigrams_r",
-                filter_list="trigrams_l",
-                output_name="trigrams_r_not_in_l",
-            )
-        },
-
-            {elsewhere_but_not_here_template.format(gram_type="trigrams")}"""
-        intermediate_cte_parts.append(trigram_section_intermediate)
-
-    # Fields for the final SELECT statement
-    select_fields_parts = [
-        """
-        unique_id_l,
-        unique_id_r,
+    cols = """
         match_weight,
         match_probability,
+        source_dataset_l,
+        unique_id_l,
+        source_dataset_r,
+        unique_id_r,
         original_address_concat_l,
-        postcode_l,
         original_address_concat_r,
+        postcode_l,
         postcode_r,
+    """
 
-        -----------------
-        -- TOKENS SECTION
-        -----------------
+    # Create a table with tokenized addresses
+    sql_token_and_bigrams = f"""
 
-        overlapping_tokens_this_l_and_r,
-        tokens_elsewhere_in_block_but_not_this,
-        hist_overlapping_tokens_r_block_l,
-        hist_all_tokens_in_block_l,
-        missing_tokens"""
-    ]
-
-    if use_bigrams:
-        bigram_fields = """
-        -----------------
-        -- BIGRAMS SECTION
-        -----------------
-
-        overlapping_bigrams_this_l_and_r,
-        bigrams_elsewhere_in_block_but_not_this,
-        hist_overlapping_bigrams_r_block_l,
-        hist_all_bigrams_in_block_l"""
-        select_fields_parts.append(bigram_fields)
-
-    if use_trigrams:
-        trigram_fields = """
-        -----------------
-        -- TRIGRAMS SECTION
-        -----------------
-
-        overlapping_trigrams_this_l_and_r,
-        trigrams_elsewhere_in_block_but_not_this,
-        hist_overlapping_trigrams_r_block_l,
-        hist_all_trigrams_in_block_l"""
-        select_fields_parts.append(trigram_fields)
-
-    # Join parts with proper separators to build the SQL
-    tokens_cte = ",\n".join(tokens_cte_parts)
-    intermediate_cte = ",\n".join(intermediate_cte_parts)
-    select_fields = ",".join(select_fields_parts)
-
-    # SQL for tokenizing and creating n-grams
-    sql_token_and_ngrams = f"""
     WITH good_matches AS (
         SELECT *
         FROM df_predict
@@ -295,11 +52,12 @@ def improve_predictions_using_distinguishing_tokens(
     tokenise_r AS (
         SELECT DISTINCT
             unique_id_r,
+
             original_address_concat_r
                 .trim()
                 .upper()
                 .regexp_split_to_array('\\s+')
-                -- .list_filter(tok -> tok NOT IN ('FLAT'))
+                .list_filter(tok -> tok NOT IN ('FLAT'))
                 as tokens_r
         FROM top_n_matches
     ),
@@ -311,7 +69,52 @@ def improve_predictions_using_distinguishing_tokens(
         -----------------
         -- TOKENS SECTION
         -----------------
-{tokens_cte}
+
+        flatten(array_agg((regexp_split_to_array(upper(trim(original_address_concat_l)), '\\s+')))) as tokens_in_block_l,
+
+        -- Counts of tokens in canonical addresses within block
+        list_aggregate(tokens_in_block_l, 'histogram') AS hist_all_tokens_in_block_l,
+
+        -- Filter to only include tokens that appear in both r and the block
+        map_from_entries(
+                list_filter(
+                    map_entries(hist_all_tokens_in_block_l),
+                    x -> list_contains(tokens_r, x.key)
+                )
+            ) AS hist_overlapping_tokens_r_block_l,
+
+        -----------------
+        -- BIGRAMS SECTION
+        -----------------
+
+        -- Create bigrams from all tokens in block
+        list_transform(
+            list_zip(
+                list_slice(tokens_in_block_l, 1, length(tokens_in_block_l) - 1),
+                list_slice(tokens_in_block_l, 2, length(tokens_in_block_l))
+            ),
+            tup -> concat_ws(' ', tup[1], tup[2])
+        ) AS bigrams_in_block_l,
+
+        -- Counts of bigrams in canonical addresses within block
+        list_aggregate(bigrams_in_block_l, 'histogram') AS hist_all_bigrams_in_block_l,
+
+        -- Create bigrams from tokens_r
+        list_transform(
+            list_zip(
+                list_slice(tokens_r, 1, length(tokens_r) - 1),
+                list_slice(tokens_r, 2, length(tokens_r))
+            ),
+            tup -> concat_ws(' ', tup[1], tup[2])
+        ) AS bigrams_r,
+
+        -- Filter to only include bigrams that appear in both r and the block
+        map_from_entries(
+            list_filter(
+                map_entries(hist_all_bigrams_in_block_l),
+                x -> list_contains(bigrams_r, x.key)
+            )
+        ) AS hist_overlapping_bigrams_r_block_l
 
         from top_n_matches m
         join tokenise_r t using (unique_id_r)
@@ -329,121 +132,169 @@ def improve_predictions_using_distinguishing_tokens(
             -----------------
             -- TOKENS SECTION
             -----------------
-{intermediate_cte},
+
+            original_address_concat_l
+                .trim()
+                .upper()
+                .regexp_split_to_array('\\s+')
+                .list_filter(tok -> tok NOT IN ('FLAT'))
+                AS tokens_l,
+            t.tokens_r,
+
+            -- Filter out any tokens not in l block!
+            map_from_entries(
+                list_filter(
+                    map_entries(hist_overlapping_tokens_r_block_l),
+                    x -> list_contains(tokens_l, x.key)
+                )
+            ) AS overlapping_tokens_this_l_and_r,
+
+            t.hist_all_tokens_in_block_l,
+            t.hist_overlapping_tokens_r_block_l,
+
+            list_filter(t.tokens_r, tok -> tok NOT IN tokens_l) as tokens_r_not_in_l,
+
+            map_from_entries(
+                list_filter(
+                    map_entries(hist_all_tokens_in_block_l),
+                    x -> list_contains(tokens_r_not_in_l, x.key)
+                )
+            ) AS tokens_elsewhere_in_block_but_not_this,
+
+            -- missing tokens are tokens in the canonical address but not in the messy address
+            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens,
+
+            -----------------
+            -- BIGRAMS SECTION
+            -----------------
+
+            -- Create bigrams from tokens_l
+            list_transform(
+                list_zip(
+                    list_slice((tokens_l), 1,
+                              length((tokens_l)) - 1),
+                    list_slice((tokens_l), 2,
+                              length((tokens_l)))
+                ),
+                tup -> concat_ws(' ', tup[1], tup[2])
+            ) AS bigrams_l,
+
+            t.bigrams_r,
+
+            -- Filter to only include bigrams that appear in both this l and r
+            map_from_entries(
+                list_filter(
+                    map_entries(hist_overlapping_bigrams_r_block_l),
+                    x -> list_contains(bigrams_l, x.key)
+                )
+            ) AS overlapping_bigrams_this_l_and_r,
+
+            t.hist_all_bigrams_in_block_l,
+            t.hist_overlapping_bigrams_r_block_l,
+
+            -- Bigrams in r but not in this l
+            list_filter(t.bigrams_r, bg -> bg NOT IN bigrams_l) as bigrams_r_not_in_l,
+
+            -- Bigrams that appear elsewhere in the block but not in this l
+            map_from_entries(
+                list_filter(
+                    map_entries(hist_all_bigrams_in_block_l),
+                    x -> list_contains(bigrams_r_not_in_l, x.key)
+                )
+            ) AS bigrams_elsewhere_in_block_but_not_this,
+
             postcode_l,
             postcode_r
         FROM top_n_matches m
         left join tokens t using (unique_id_r)
     )
-    SELECT{select_fields}
+    SELECT
+        unique_id_l,
+        unique_id_r,
+        match_weight,
+        match_probability,
+        original_address_concat_l,
+        postcode_l,
+        original_address_concat_r,
+        postcode_r,
+
+        -----------------
+        -- TOKENS SECTION
+        -----------------
+
+        overlapping_tokens_this_l_and_r,
+        tokens_elsewhere_in_block_but_not_this,
+        hist_overlapping_tokens_r_block_l,
+        hist_all_tokens_in_block_l,
+        missing_tokens,
+
+        -----------------
+        -- BIGRAMS SECTION
+        -----------------
+
+        overlapping_bigrams_this_l_and_r,
+        bigrams_elsewhere_in_block_but_not_this,
+        hist_overlapping_bigrams_r_block_l,
+        hist_all_bigrams_in_block_l
+
     FROM intermediate
     ORDER BY unique_id_r;
     """
-    # print(sql_token_and_ngrams)
 
-    windowed_tokens = con.sql(sql_token_and_ngrams)
+    windowed_tokens = con.sql(sql_token_and_bigrams)
 
-    # Define multipliers for each n-gram type
+    # Calculate new match weights based on distinguishing tokens and bigrams
+
     overall_reward_multiplier = 1.5
     REWARD_MULTIPLIER = 2 * overall_reward_multiplier
     PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
     BIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
     BIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
-    TRIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
-    TRIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
-
-    # Base adjustment for tokens (always included)
-    adjustment_parts = [
-        f"""
-        -- Token-based adjustments
-        {
-            adjustment_template.format(
-                gram_type="tokens",
-                reward_multiplier=REWARD_MULTIPLIER,
-                punishment_multiplier=PUNISHMENT_MULTIPLIER,
-            )
-        }
-        - (0.1 * len(missing_tokens))"""
-    ]
-
-    # Add bigram adjustment if enabled
-    if use_bigrams:
-        bigram_adjustment = f"""
-        -- Bigram-based adjustments
-        + {
-            adjustment_template.format(
-                gram_type="bigrams",
-                reward_multiplier=BIGRAM_REWARD_MULTIPLIER,
-                punishment_multiplier=BIGRAM_PUNISHMENT_MULTIPLIER,
-            )
-        }"""
-        adjustment_parts.append(bigram_adjustment)
-
-    # Add trigram adjustment if enabled
-    if use_trigrams:
-        trigram_adjustment = f"""
-        -- Trigram-based adjustments
-        + {
-            adjustment_template.format(
-                gram_type="trigrams",
-                reward_multiplier=TRIGRAM_REWARD_MULTIPLIER,
-                punishment_multiplier=TRIGRAM_PUNISHMENT_MULTIPLIER,
-            )
-        }"""
-        adjustment_parts.append(trigram_adjustment)
-
-    # Join adjustment parts
-    adjustment_expr = "\n".join(adjustment_parts)
-
-    # Output fields for final SELECT
-    output_fields_parts = [
-        """
-        -- Token-related fields
-        overlapping_tokens_this_l_and_r,
-        tokens_elsewhere_in_block_but_not_this,
-        missing_tokens"""
-    ]
-
-    if use_bigrams:
-        output_fields_parts.append("""
-        -- Bigram-related fields
-        overlapping_bigrams_this_l_and_r,
-        bigrams_elsewhere_in_block_but_not_this""")
-
-    if use_trigrams:
-        output_fields_parts.append("""
-        -- Trigram-related fields
-        overlapping_trigrams_this_l_and_r,
-        trigrams_elsewhere_in_block_but_not_this""")
-
-    output_fields_parts.append("""
-        original_address_concat_l,
-        postcode_l,
-        original_address_concat_r,
-        postcode_r""")
-
-    output_fields = ",".join(output_fields_parts)
-
-    # Calculate new match weights based on distinguishing tokens, bigrams and trigrams
     sql = f"""
     CREATE OR REPLACE TABLE matches AS
 
     SELECT
         unique_id_r,
         unique_id_l,
-        {adjustment_expr}
+
+        -- Token-based adjustments
+        ifnull(map_values(overlapping_tokens_this_l_and_r)
+            .list_transform(x -> 1/(x^2))
+            .list_sum() *  {REWARD_MULTIPLIER}, 0)
+        - map_values(tokens_elsewhere_in_block_but_not_this)
+            .length() * {PUNISHMENT_MULTIPLIER}
+        - (0.1 * len(missing_tokens))
+
+        -- Bigram-based adjustments
+        + ifnull(map_values(overlapping_bigrams_this_l_and_r)
+            .list_transform(x -> 1/(x^2))
+            .list_sum() * {BIGRAM_REWARD_MULTIPLIER}, 0)
+        - map_values(bigrams_elsewhere_in_block_but_not_this)
+            .length() * {BIGRAM_PUNISHMENT_MULTIPLIER}
         as mw_adjustment,
 
         match_weight AS match_weight_original,
         match_probability AS match_probability_original,
         (match_weight_original + mw_adjustment) AS match_weight,
         pow(2, match_weight)/(1+pow(2, match_weight)) AS match_probability,
-        {output_fields}
+
+        -- Token-related fields
+        overlapping_tokens_this_l_and_r,
+        tokens_elsewhere_in_block_but_not_this,
+        missing_tokens,
+
+        -- Bigram-related fields
+        overlapping_bigrams_this_l_and_r,
+        bigrams_elsewhere_in_block_but_not_this,
+
+        original_address_concat_l,
+        postcode_l,
+        original_address_concat_r,
+        postcode_r
 
     FROM windowed_tokens
     """
 
     con.execute(sql)
-
     matches = con.table("matches")
     return matches


### PR DESCRIPTION
<details>
<summary>improve_predictions_using_distinguishing_tokens before DRYing bi trigrams</summary>

```python
from duckdb import DuckDBPyRelation, DuckDBPyConnection


def improve_predictions_using_distinguishing_tokens(
    *,
    df_predict: DuckDBPyRelation,
    con: DuckDBPyConnection,
    match_weight_threshold: float = -20,
    top_n_matches: int = 5,
):
    """
    Improve match predictions by identifying distinguishing tokens between addresses.

    Args:
        df_predict: DuckDB relation containing the prediction data
        con: DuckDB connection
        match_weight_threshold: Minimum match weight to consider
        top_n_matches: Number of top matches to consider for each unique_id_r

    Returns:
        DuckDBPyRelation: Table with improved match predictions
    """
    cols = """
        match_weight,
        match_probability,
        source_dataset_l,
        unique_id_l,
        source_dataset_r,
        unique_id_r,
        original_address_concat_l,
        original_address_concat_r,
        postcode_l,
        postcode_r,
    """

    # Create a table with tokenized addresses
    sql_token_and_bigrams = f"""

    WITH good_matches AS (
        SELECT *
        FROM df_predict
        WHERE match_weight > {match_weight_threshold}
    ),
    top_n_matches AS (
        SELECT *
        FROM good_matches
        QUALIFY ROW_NUMBER() OVER (
            PARTITION BY unique_id_r
            ORDER BY match_weight DESC
        ) <= {top_n_matches}  -- e.g., 5 for top 5 matches
    ),
    tokenise_r AS (
        SELECT DISTINCT
            unique_id_r,

            original_address_concat_r
                .trim()
                .upper()
                .regexp_split_to_array('\\s+')
                .list_filter(tok -> tok NOT IN ('FLAT'))
                as tokens_r
        FROM top_n_matches
    ),
    tokens as (
        select
        t.unique_id_r,
        t.tokens_r,

        -----------------
        -- TOKENS SECTION
        -----------------

        flatten(array_agg((regexp_split_to_array(upper(trim(original_address_concat_l)), '\\s+')))) as tokens_in_block_l,

        -- Counts of tokens in canonical addresses within block
        list_aggregate(tokens_in_block_l, 'histogram') AS hist_all_tokens_in_block_l,

        -- Filter to only include tokens that appear in both r and the block
        map_from_entries(
                list_filter(
                    map_entries(hist_all_tokens_in_block_l),
                    x -> list_contains(tokens_r, x.key)
                )
            ) AS hist_overlapping_tokens_r_block_l,

        -----------------
        -- BIGRAMS SECTION
        -----------------

        -- Create bigrams from all tokens in block
        list_transform(
            list_zip(
                list_slice(tokens_in_block_l, 1, length(tokens_in_block_l) - 1),
                list_slice(tokens_in_block_l, 2, length(tokens_in_block_l))
            ),
            tup -> concat_ws(' ', tup[1], tup[2])
        ) AS bigrams_in_block_l,

        -- Counts of bigrams in canonical addresses within block
        list_aggregate(bigrams_in_block_l, 'histogram') AS hist_all_bigrams_in_block_l,

        -- Create bigrams from tokens_r
        list_transform(
            list_zip(
                list_slice(tokens_r, 1, length(tokens_r) - 1),
                list_slice(tokens_r, 2, length(tokens_r))
            ),
            tup -> concat_ws(' ', tup[1], tup[2])
        ) AS bigrams_r,

        -- Filter to only include bigrams that appear in both r and the block
        map_from_entries(
            list_filter(
                map_entries(hist_all_bigrams_in_block_l),
                x -> list_contains(bigrams_r, x.key)
            )
        ) AS hist_overlapping_bigrams_r_block_l

        from top_n_matches m
        join tokenise_r t using (unique_id_r)
        group by t.unique_id_r, t.tokens_r
    ),
    intermediate AS (
        SELECT
            match_weight,
            match_probability,
            unique_id_l,
            m.unique_id_r,
            original_address_concat_l,
            original_address_concat_r,

            -----------------
            -- TOKENS SECTION
            -----------------

            original_address_concat_l
                .trim()
                .upper()
                .regexp_split_to_array('\\s+')
                .list_filter(tok -> tok NOT IN ('FLAT'))
                AS tokens_l,
            t.tokens_r,

            -- Filter out any tokens not in l block!
            map_from_entries(
                list_filter(
                    map_entries(hist_overlapping_tokens_r_block_l),
                    x -> list_contains(tokens_l, x.key)
                )
            ) AS overlapping_tokens_this_l_and_r,

            t.hist_all_tokens_in_block_l,
            t.hist_overlapping_tokens_r_block_l,

            list_filter(t.tokens_r, tok -> tok NOT IN tokens_l) as tokens_r_not_in_l,

            map_from_entries(
                list_filter(
                    map_entries(hist_all_tokens_in_block_l),
                    x -> list_contains(tokens_r_not_in_l, x.key)
                )
            ) AS tokens_elsewhere_in_block_but_not_this,

            -- missing tokens are tokens in the canonical address but not in the messy address
            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens,

            -----------------
            -- BIGRAMS SECTION
            -----------------

            -- Create bigrams from tokens_l
            list_transform(
                list_zip(
                    list_slice((tokens_l), 1,
                              length((tokens_l)) - 1),
                    list_slice((tokens_l), 2,
                              length((tokens_l)))
                ),
                tup -> concat_ws(' ', tup[1], tup[2])
            ) AS bigrams_l,

            t.bigrams_r,

            -- Filter to only include bigrams that appear in both this l and r
            map_from_entries(
                list_filter(
                    map_entries(hist_overlapping_bigrams_r_block_l),
                    x -> list_contains(bigrams_l, x.key)
                )
            ) AS overlapping_bigrams_this_l_and_r,

            t.hist_all_bigrams_in_block_l,
            t.hist_overlapping_bigrams_r_block_l,

            -- Bigrams in r but not in this l
            list_filter(t.bigrams_r, bg -> bg NOT IN bigrams_l) as bigrams_r_not_in_l,

            -- Bigrams that appear elsewhere in the block but not in this l
            map_from_entries(
                list_filter(
                    map_entries(hist_all_bigrams_in_block_l),
                    x -> list_contains(bigrams_r_not_in_l, x.key)
                )
            ) AS bigrams_elsewhere_in_block_but_not_this,

            postcode_l,
            postcode_r
        FROM top_n_matches m
        left join tokens t using (unique_id_r)
    )
    SELECT
        unique_id_l,
        unique_id_r,
        match_weight,
        match_probability,
        original_address_concat_l,
        postcode_l,
        original_address_concat_r,
        postcode_r,

        -----------------
        -- TOKENS SECTION
        -----------------

        overlapping_tokens_this_l_and_r,
        tokens_elsewhere_in_block_but_not_this,
        hist_overlapping_tokens_r_block_l,
        hist_all_tokens_in_block_l,
        missing_tokens,

        -----------------
        -- BIGRAMS SECTION
        -----------------

        overlapping_bigrams_this_l_and_r,
        bigrams_elsewhere_in_block_but_not_this,
        hist_overlapping_bigrams_r_block_l,
        hist_all_bigrams_in_block_l

    FROM intermediate
    ORDER BY unique_id_r;
    """

    windowed_tokens = con.sql(sql_token_and_bigrams)

    # Calculate new match weights based on distinguishing tokens and bigrams

    REWARD_MULTIPLIER = 2
    PUNISHMENT_MULTIPLIER = 2
    BIGRAM_REWARD_MULTIPLIER = 3
    BIGRAM_PUNISHMENT_MULTIPLIER = 3
    sql = f"""
    CREATE OR REPLACE TABLE matches AS

    SELECT
        unique_id_r,
        unique_id_l,

        -- Token-based adjustments
        map_values(overlapping_tokens_this_l_and_r)
            .list_transform(x -> 1/(x^2))
            .list_sum() *  {REWARD_MULTIPLIER}
        - map_values(tokens_elsewhere_in_block_but_not_this)
            .length() * {PUNISHMENT_MULTIPLIER}
        - (0.1 * len(missing_tokens))

        -- Bigram-based adjustments
        + map_values(overlapping_bigrams_this_l_and_r)
            .list_transform(x -> 1/(x^2))
            .list_sum() * {BIGRAM_REWARD_MULTIPLIER}
        - map_values(bigrams_elsewhere_in_block_but_not_this)
            .length() * {BIGRAM_PUNISHMENT_MULTIPLIER}
        as mw_adjustment,

        match_weight AS match_weight_original,
        match_probability AS match_probability_original,
        (match_weight_original + mw_adjustment) AS match_weight,
        pow(2, match_weight)/(1+pow(2, match_weight)) AS match_probability,

        -- Token-related fields
        overlapping_tokens_this_l_and_r,
        tokens_elsewhere_in_block_but_not_this,
        missing_tokens,

        -- Bigram-related fields
        overlapping_bigrams_this_l_and_r,
        bigrams_elsewhere_in_block_but_not_this,

        original_address_concat_l,
        postcode_l,
        original_address_concat_r,
        postcode_r

    FROM windowed_tokens
    """

    con.execute(sql)
    matches = con.table("matches")
    return matches

```
</details>

<details>
<summary>After DRYing bi and tri</summary>

```python
from duckdb import DuckDBPyRelation, DuckDBPyConnection


def improve_predictions_using_distinguishing_tokens(
    *,
    df_predict: DuckDBPyRelation,
    con: DuckDBPyConnection,
    match_weight_threshold: float = -20,
    top_n_matches: int = 5,
    use_bigrams: bool = True,
    use_trigrams: bool = True,
):
    """
    Improve match predictions by identifying distinguishing tokens between addresses.

    Args:
        df_predict: DuckDB relation containing the prediction data
        con: DuckDB connection
        match_weight_threshold: Minimum match weight to consider
        top_n_matches: Number of top matches to consider for each unique_id_r
        use_bigrams: Whether to use bigram analysis in matching
        use_trigrams: Whether to use trigram analysis in matching

    Returns:
        DuckDBPyRelation: Table with improved match predictions
    """
    # Define template strings for n-gram operations

    # Template for creating n-grams from a token list
    ngram_template = """
    -- Create {gram_type} from {token_list}
    list_transform(
        list_zip(
            {zip_parts}
        ),
        tup -> {concat_parts}
    ) AS {output_name}"""

    # Function to generate n-gram creation SQL
    def generate_ngram_sql(gram_type, token_list, output_name):
        n = 1
        if gram_type == "bigrams":
            n = 2
        elif gram_type == "trigrams":
            n = 3

        zip_parts = []
        concat_parts = []

        for i in range(1, n + 1):
            zip_parts.append(
                f"list_slice({token_list}, {i}, length({token_list}) - {n - i})"
            )

        concat_parts_str = "concat_ws(' '"
        for i in range(1, n + 1):
            concat_parts_str += f", tup[{i}]"
        concat_parts_str += ")"

        return ngram_template.format(
            gram_type=gram_type,
            token_list=token_list,
            zip_parts=",\n                ".join(zip_parts),
            concat_parts=concat_parts_str,
            output_name=output_name,
        )

    # Template for histogram overlapping calculations
    histogram_overlap_template = """
    -- Filter to only include {gram_type} that appear in both r and the block
    map_from_entries(
        list_filter(
            map_entries(hist_all_{gram_type}_in_block_l),
            x -> list_contains({gram_type}_r, x.key)
        )
    ) AS hist_overlapping_{gram_type}_r_block_l"""

    # Template for filtering to items not in another list
    not_in_list_template = """
    -- {gram_type} in r but not in this l
    list_filter({source_list}, item -> item NOT IN {filter_list}) as {output_name}"""

    # Template for creating map from entries that overlap
    overlap_map_template = """
    -- Filter to only include {gram_type} that appear in both this l and r
    map_from_entries(
        list_filter(
            map_entries(hist_overlapping_{gram_type}_r_block_l),
            x -> list_contains({gram_type}_l, x.key)
        )
    ) AS overlapping_{gram_type}_this_l_and_r"""

    # Template for items that appear elsewhere but not in this item
    elsewhere_but_not_here_template = """
    -- {gram_type} that appear elsewhere in the block but not in this l
    map_from_entries(
        list_filter(
            map_entries(hist_all_{gram_type}_in_block_l),
            x -> list_contains({gram_type}_r_not_in_l, x.key)
        )
    ) AS {gram_type}_elsewhere_in_block_but_not_this"""

    # Template for the adjustment formula in the final SQL
    adjustment_template = """ifnull(map_values(overlapping_{gram_type}_this_l_and_r)
        .list_transform(x -> 1/(x^2))
        .list_sum() * {reward_multiplier}, 0)
    - map_values({gram_type}_elsewhere_in_block_but_not_this)
        .length() * {punishment_multiplier}"""

    # Token section is always included
    tokens_section_cte = f"""
        flatten(array_agg((regexp_split_to_array(upper(trim(original_address_concat_l)), '\\s+')))) as tokens_in_block_l,

        -- Counts of tokens in canonical addresses within block
        list_aggregate(tokens_in_block_l, 'histogram') AS hist_all_tokens_in_block_l,

        {histogram_overlap_template.format(gram_type="tokens")}"""

    # Prepare parts of the SQL that depend on use_bigrams and use_trigrams
    tokens_cte_parts = [tokens_section_cte]

    if use_bigrams:
        bigram_section_tokens = f"""
        -- Create bigrams from all tokens in block
        {generate_ngram_sql("bigrams", "tokens_in_block_l", "bigrams_in_block_l")},

        -- Counts of bigrams in canonical addresses within block
        list_aggregate(bigrams_in_block_l, 'histogram') AS hist_all_bigrams_in_block_l,

        -- Create bigrams from tokens_r
        {generate_ngram_sql("bigrams", "tokens_r", "bigrams_r")},

        {histogram_overlap_template.format(gram_type="bigrams")}"""
        tokens_cte_parts.append(bigram_section_tokens)

    if use_trigrams:
        trigram_section_tokens = f"""
        -- Create trigrams from all tokens in block
        {generate_ngram_sql("trigrams", "tokens_in_block_l", "trigrams_in_block_l")},

        -- Counts of trigrams in canonical addresses within block
        list_aggregate(trigrams_in_block_l, 'histogram') AS hist_all_trigrams_in_block_l,

        -- Create trigrams from tokens_r
        {generate_ngram_sql("trigrams", "tokens_r", "trigrams_r")},

        {histogram_overlap_template.format(gram_type="trigrams")}"""
        tokens_cte_parts.append(trigram_section_tokens)

    # Token section for intermediate CTE is always included
    intermediate_cte_parts = [
        f"""
            original_address_concat_l
                .trim()
                .upper()
                .regexp_split_to_array('\\s+')
                AS tokens_l,
            t.tokens_r,

            {overlap_map_template.format(gram_type="tokens")},

            t.hist_all_tokens_in_block_l,
            t.hist_overlapping_tokens_r_block_l,

            {
            not_in_list_template.format(
                gram_type="Tokens",
                source_list="t.tokens_r",
                filter_list="tokens_l",
                output_name="tokens_r_not_in_l",
            )
        },

            {elsewhere_but_not_here_template.format(gram_type="tokens")},

            -- missing tokens are tokens in the canonical address but not in the messy address
            list_filter(tokens_l, t -> t NOT IN tokens_r) AS missing_tokens"""
    ]

    if use_bigrams:
        bigram_section_intermediate = f"""
            -- Create bigrams from tokens_l
            {generate_ngram_sql("bigrams", "(tokens_l)", "bigrams_l")},

            t.bigrams_r,

            {overlap_map_template.format(gram_type="bigrams")},

            t.hist_all_bigrams_in_block_l,
            t.hist_overlapping_bigrams_r_block_l,

            {
            not_in_list_template.format(
                gram_type="Bigrams",
                source_list="t.bigrams_r",
                filter_list="bigrams_l",
                output_name="bigrams_r_not_in_l",
            )
        },

            {elsewhere_but_not_here_template.format(gram_type="bigrams")}"""
        intermediate_cte_parts.append(bigram_section_intermediate)

    if use_trigrams:
        trigram_section_intermediate = f"""
            -- Create trigrams from tokens_l
            {generate_ngram_sql("trigrams", "(tokens_l)", "trigrams_l")},

            t.trigrams_r,

            {overlap_map_template.format(gram_type="trigrams")},

            t.hist_all_trigrams_in_block_l,
            t.hist_overlapping_trigrams_r_block_l,

            {
            not_in_list_template.format(
                gram_type="Trigrams",
                source_list="t.trigrams_r",
                filter_list="trigrams_l",
                output_name="trigrams_r_not_in_l",
            )
        },

            {elsewhere_but_not_here_template.format(gram_type="trigrams")}"""
        intermediate_cte_parts.append(trigram_section_intermediate)

    # Fields for the final SELECT statement
    select_fields_parts = [
        """
        unique_id_l,
        unique_id_r,
        match_weight,
        match_probability,
        original_address_concat_l,
        postcode_l,
        original_address_concat_r,
        postcode_r,

        -----------------
        -- TOKENS SECTION
        -----------------

        overlapping_tokens_this_l_and_r,
        tokens_elsewhere_in_block_but_not_this,
        hist_overlapping_tokens_r_block_l,
        hist_all_tokens_in_block_l,
        missing_tokens"""
    ]

    if use_bigrams:
        bigram_fields = """
        -----------------
        -- BIGRAMS SECTION
        -----------------

        overlapping_bigrams_this_l_and_r,
        bigrams_elsewhere_in_block_but_not_this,
        hist_overlapping_bigrams_r_block_l,
        hist_all_bigrams_in_block_l"""
        select_fields_parts.append(bigram_fields)

    if use_trigrams:
        trigram_fields = """
        -----------------
        -- TRIGRAMS SECTION
        -----------------

        overlapping_trigrams_this_l_and_r,
        trigrams_elsewhere_in_block_but_not_this,
        hist_overlapping_trigrams_r_block_l,
        hist_all_trigrams_in_block_l"""
        select_fields_parts.append(trigram_fields)

    # Join parts with proper separators to build the SQL
    tokens_cte = ",\n".join(tokens_cte_parts)
    intermediate_cte = ",\n".join(intermediate_cte_parts)
    select_fields = ",".join(select_fields_parts)

    # SQL for tokenizing and creating n-grams
    sql_token_and_ngrams = f"""
    WITH good_matches AS (
        SELECT *
        FROM df_predict
        WHERE match_weight > {match_weight_threshold}
    ),
    top_n_matches AS (
        SELECT *
        FROM good_matches
        QUALIFY ROW_NUMBER() OVER (
            PARTITION BY unique_id_r
            ORDER BY match_weight DESC
        ) <= {top_n_matches}  -- e.g., 5 for top 5 matches
    ),
    tokenise_r AS (
        SELECT DISTINCT
            unique_id_r,
            original_address_concat_r
                .trim()
                .upper()
                .regexp_split_to_array('\\s+')
                -- .list_filter(tok -> tok NOT IN ('FLAT'))
                as tokens_r
        FROM top_n_matches
    ),
    tokens as (
        select
        t.unique_id_r,
        t.tokens_r,

        -----------------
        -- TOKENS SECTION
        -----------------
{tokens_cte}

        from top_n_matches m
        join tokenise_r t using (unique_id_r)
        group by t.unique_id_r, t.tokens_r
    ),
    intermediate AS (
        SELECT
            match_weight,
            match_probability,
            unique_id_l,
            m.unique_id_r,
            original_address_concat_l,
            original_address_concat_r,

            -----------------
            -- TOKENS SECTION
            -----------------
{intermediate_cte},
            postcode_l,
            postcode_r
        FROM top_n_matches m
        left join tokens t using (unique_id_r)
    )
    SELECT{select_fields}
    FROM intermediate
    ORDER BY unique_id_r;
    """
    # print(sql_token_and_ngrams)

    windowed_tokens = con.sql(sql_token_and_ngrams)

    # Define multipliers for each n-gram type
    overall_reward_multiplier = 1.5
    REWARD_MULTIPLIER = 2 * overall_reward_multiplier
    PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
    BIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
    BIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier
    TRIGRAM_REWARD_MULTIPLIER = 2 * overall_reward_multiplier
    TRIGRAM_PUNISHMENT_MULTIPLIER = 3 * overall_reward_multiplier

    # Base adjustment for tokens (always included)
    adjustment_parts = [
        f"""
        -- Token-based adjustments
        {
            adjustment_template.format(
                gram_type="tokens",
                reward_multiplier=REWARD_MULTIPLIER,
                punishment_multiplier=PUNISHMENT_MULTIPLIER,
            )
        }
        - (0.1 * len(missing_tokens))"""
    ]

    # Add bigram adjustment if enabled
    if use_bigrams:
        bigram_adjustment = f"""
        -- Bigram-based adjustments
        + {
            adjustment_template.format(
                gram_type="bigrams",
                reward_multiplier=BIGRAM_REWARD_MULTIPLIER,
                punishment_multiplier=BIGRAM_PUNISHMENT_MULTIPLIER,
            )
        }"""
        adjustment_parts.append(bigram_adjustment)

    # Add trigram adjustment if enabled
    if use_trigrams:
        trigram_adjustment = f"""
        -- Trigram-based adjustments
        + {
            adjustment_template.format(
                gram_type="trigrams",
                reward_multiplier=TRIGRAM_REWARD_MULTIPLIER,
                punishment_multiplier=TRIGRAM_PUNISHMENT_MULTIPLIER,
            )
        }"""
        adjustment_parts.append(trigram_adjustment)

    # Join adjustment parts
    adjustment_expr = "\n".join(adjustment_parts)

    # Output fields for final SELECT
    output_fields_parts = [
        """
        -- Token-related fields
        overlapping_tokens_this_l_and_r,
        tokens_elsewhere_in_block_but_not_this,
        missing_tokens"""
    ]

    if use_bigrams:
        output_fields_parts.append("""
        -- Bigram-related fields
        overlapping_bigrams_this_l_and_r,
        bigrams_elsewhere_in_block_but_not_this""")

    if use_trigrams:
        output_fields_parts.append("""
        -- Trigram-related fields
        overlapping_trigrams_this_l_and_r,
        trigrams_elsewhere_in_block_but_not_this""")

    output_fields_parts.append("""
        original_address_concat_l,
        postcode_l,
        original_address_concat_r,
        postcode_r""")

    output_fields = ",".join(output_fields_parts)

    # Calculate new match weights based on distinguishing tokens, bigrams and trigrams
    sql = f"""
    CREATE OR REPLACE TABLE matches AS

    SELECT
        unique_id_r,
        unique_id_l,
        {adjustment_expr}
        as mw_adjustment,

        match_weight AS match_weight_original,
        match_probability AS match_probability_original,
        (match_weight_original + mw_adjustment) AS match_weight,
        pow(2, match_weight)/(1+pow(2, match_weight)) AS match_probability,
        {output_fields}

    FROM windowed_tokens
    """

    con.execute(sql)

    matches = con.table("matches")
    return matches

```
</details>