### PR TITLE
Hash not limit offset for chunking

### DIFF
--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -6,7 +6,7 @@ from uk_address_matcher.cleaning.steps import (
     _add_term_frequencies_to_address_tokens_using_registered_df,
     _add_ukam_address_id,
     _canonicalise_postcode,
-    # _classify_non_traditional_address,
+    _classify_non_traditional_address,
     _clean_address_string_first_pass,
     _clean_address_string_second_pass,
     _first_unusual_token,
@@ -53,7 +53,7 @@ QUEUE_PRE_TF = [
     _clean_address_string_second_pass,
     _split_numeric_tokens_to_cols,
     _tokenise_address_without_numbers,
-    # _classify_non_traditional_address,
+    _classify_non_traditional_address,
 ]
 
 COMMON_AND_UNIQUE = [


### PR DESCRIPTION
DuckDB TIL:
`LIMIT` and `OFFSET` can sometimes prevent parallelisation

So if you think 'oh, i'll run a test on a subset of the full dataset' and then load your data in like
`con.read_parquet().limit(1e6)`

That can prevent the whole of the rest of the pipeline parallelising

On way to fix is to use the same trick we use in Splink 5:
`.filter("abs(hash(some_uniqueish_column)) % 100 = 0")`

where `some_uniqueish_column` should be high cardinality and not skewed, ideally an id column