### PR TITLE
Refactor: rename cleaning functions to improve clarity and consistency

### DIFF
--- a/benchmarking/datasets/__init__.py
+++ b/benchmarking/datasets/__init__.py
@@ -26,8 +26,8 @@ from benchmarking.datasets.sources import (
     load_canonical_data,
 )
 from uk_address_matcher import (
-    clean_data_with_minimal_steps,
-    clean_data_with_term_frequencies,
+    clean_data_pre_term_frequencies,
+    prepare_data_for_matching,
 )
 
 if TYPE_CHECKING:
@@ -77,9 +77,9 @@ def load_benchmark_data(
 
     # Apply cleaning logic
     if include_term_frequencies:
-        cleaning_function = clean_data_with_term_frequencies
+        cleaning_function = prepare_data_for_matching
     else:
-        cleaning_function = clean_data_with_minimal_steps
+        cleaning_function = clean_data_pre_term_frequencies
 
     df_messy = cleaning_function(df_messy_raw, con)
 

--- a/examples/example_matching.py
+++ b/examples/example_matching.py
@@ -9,7 +9,7 @@ from uk_address_matcher import (
     best_matches_summary,
     best_matches_with_distinguishability,
     calculate_match_metrics,
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
     improve_predictions_using_distinguishing_tokens,
 )
@@ -59,8 +59,8 @@ if os.getenv("TEST_LIMIT"):
 # -----------------------------------------------------------------------------
 # Step 2: Clean the data/feature engineering to prepare for matching model
 # -----------------------------------------------------------------------------
-df_ch_clean = clean_data_with_term_frequencies(df_ch, con=con)
-df_fhrs_clean = clean_data_with_term_frequencies(df_fhrs, con=con)
+df_ch_clean = prepare_data_for_matching(df_ch, con=con)
+df_fhrs_clean = prepare_data_for_matching(df_fhrs, con=con)
 
 # -----------------------------------------------------------------------------
 # Step 3: Run exact matching to reduce the number of records to consider

--- a/examples/fhrs/match_fhrs_to_os.py
+++ b/examples/fhrs/match_fhrs_to_os.py
@@ -6,7 +6,7 @@ import duckdb
 from IPython.display import display
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
 )
 from uk_address_matcher.post_linkage.analyse_results import (
@@ -84,7 +84,7 @@ and description != 'Non Addressable Object'
 """
 con.execute(sql)
 df_os = con.table("os")
-df_os_clean = clean_data_with_term_frequencies(df_os, con=con)
+df_os_clean = prepare_data_for_matching(df_os, con=con)
 
 # -----------------------------------------------------------------------------
 # Step 2: Clean data
@@ -94,7 +94,7 @@ df_os_clean = clean_data_with_term_frequencies(df_os, con=con)
 messy_count = df_messy.count("*").fetchall()[0][0]
 canonical_count = df_os_clean.count("*").fetchall()[0][0]
 
-df_messy_clean = clean_data_with_term_frequencies(df_messy, con=con)
+df_messy_clean = prepare_data_for_matching(df_messy, con=con)
 
 
 end_time = time.time()

--- a/examples/match_epc_to_os.py
+++ b/examples/match_epc_to_os.py
@@ -4,7 +4,7 @@ import time
 import duckdb
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
 )
 from uk_address_matcher.post_linkage.analyse_results import (
@@ -75,8 +75,8 @@ canonical_count = df_os.count("*").fetchall()[0][0]
 # -----------------------------------------------------------------------------
 
 
-df_epc_data_clean = clean_data_with_term_frequencies(df_epc_data, con=con)
-df_os_clean = clean_data_with_term_frequencies(df_os, con=con)
+df_epc_data_clean = prepare_data_for_matching(df_epc_data, con=con)
+df_os_clean = prepare_data_for_matching(df_os, con=con)
 
 end_time = time.time()
 print(f"Time to load/clean: {end_time - overall_start_time} seconds")

--- a/examples/match_one.py
+++ b/examples/match_one.py
@@ -3,7 +3,7 @@ import os
 import duckdb
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
     run_deterministic_match_pass,
 )
@@ -32,7 +32,7 @@ df_messy = con.table("df_messy")
 print(" - messy records prepared:", df_messy.count("*").fetchall()[0][0])
 
 # Step 2: Clean the messy record using the standard pipeline
-df_messy_clean = clean_data_with_term_frequencies(df_messy, con=con)
+df_messy_clean = prepare_data_for_matching(df_messy, con=con)
 df_messy_clean.show(max_width=5000, max_rows=20)
 
 

--- a/examples/preclean_full_os.py
+++ b/examples/preclean_full_os.py
@@ -6,7 +6,7 @@ import duckdb
 
 from uk_address_matcher import (
     clean_data_on_the_fly,
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
 )
 
 overall_start_time = time.time()
@@ -34,7 +34,7 @@ df_os
 
 
 df_os_clean = clean_data_on_the_fly(df_os, con=con)
-df_os_clean = clean_data_with_term_frequencies(df_os, con=con)
+df_os_clean = prepare_data_for_matching(df_os, con=con)
 df_os_clean.write_parquet("secret_data/ord_surv/os_clean.parquet")
 df_os_clean_from_file = duckdb.read_parquet("secret_data/ord_surv/os_clean.parquet")
 df_os_clean_from_file.show(max_width=50000)

--- a/scripts/accuracy_from_labels.py
+++ b/scripts/accuracy_from_labels.py
@@ -2,7 +2,7 @@ import duckdb
 import pandas as pd
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     evaluate_predictions_against_labels,
     get_linker,
     inspect_match_results_vs_labels,
@@ -67,11 +67,11 @@ labels_rel = duckdb_con.sql("""
 df_os_rel = canonical_addresses_raw
 messy_data_rel = messy_addresses_raw
 
-df_messy_data_clean_rel = clean_data_with_term_frequencies(
+df_messy_data_clean_rel = prepare_data_for_matching(
     messy_data_rel.select("unique_id", "address_concat", "postcode"), con=duckdb_con
 )
 
-df_os_clean_rel = clean_data_with_term_frequencies(
+df_os_clean_rel = prepare_data_for_matching(
     duckdb_con.from_df(df_os_rel), con=duckdb_con
 )
 

--- a/scripts/analyse_test_cases.py
+++ b/scripts/analyse_test_cases.py
@@ -2,7 +2,7 @@ import duckdb
 from splink import block_on
 
 from tests.utils import prepare_combined_test_data
-from uk_address_matcher import clean_data_with_term_frequencies, get_linker
+from uk_address_matcher import prepare_data_for_matching, get_linker
 from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
     improve_predictions_using_distinguishing_tokens,
 )
@@ -25,8 +25,8 @@ messy_addresses
 canonical_addresses = canonical_addresses.filter(f"test_block = {test_block}")
 canonical_addresses
 # Clean the input data
-messy_clean = clean_data_with_term_frequencies(messy_addresses, con=duckdb_con)
-canonical_clean = clean_data_with_term_frequencies(canonical_addresses, con=duckdb_con)
+messy_clean = prepare_data_for_matching(messy_addresses, con=duckdb_con)
+canonical_clean = prepare_data_for_matching(canonical_addresses, con=duckdb_con)
 
 # Configure the linker
 columns_to_retain = ["original_address_concat", "true_match_id"]

--- a/scripts/epc_accuracy_from_labels.py
+++ b/scripts/epc_accuracy_from_labels.py
@@ -4,7 +4,7 @@ import duckdb
 from IPython.display import display
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
 )
 from uk_address_matcher.linking_model.training import get_settings_for_training
@@ -88,8 +88,8 @@ print(f"messy_count: {messy_count:,}, canonical_count: {canonical_count:,}")
 # -----------------------------------------------------------------------------
 
 
-df_epc_data_clean = clean_data_with_term_frequencies(con.from_df(df_epc_data), con=con)
-df_os_clean = clean_data_with_term_frequencies(con.from_df(df_os), con=con)
+df_epc_data_clean = prepare_data_for_matching(con.from_df(df_epc_data), con=con)
+df_os_clean = prepare_data_for_matching(con.from_df(df_os), con=con)
 
 end_time = time.time()
 print(f"Time to load/clean: {end_time - overall_start_time} seconds")

--- a/scripts/improve_parameters_using_gradient_descent.py
+++ b/scripts/improve_parameters_using_gradient_descent.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
 )
 from uk_address_matcher.linking_model.training import get_settings_for_training
@@ -87,7 +87,7 @@ df_epc_data = con_disk.sql("select * exclude (uprn,uprn_source) from epc_data_ra
 # Step 2: Clean data
 # -----------------------------------------------------------------------------
 
-df_epc_data_clean = clean_data_with_term_frequencies(
+df_epc_data_clean = prepare_data_for_matching(
     con_disk.from_df(df_epc_data), con=con_disk
 )
 sql = """
@@ -97,7 +97,7 @@ select * from df_epc_data_clean
 con_disk.execute(sql)
 
 
-df_os_clean = clean_data_with_term_frequencies(con_disk.from_df(df_os), con=con_disk)
+df_os_clean = prepare_data_for_matching(con_disk.from_df(df_os), con=con_disk)
 sql = """
 create table os_clean as
 select * from df_os_clean

--- a/scripts/improve_parameters_using_gradient_descent_non_spsa.py
+++ b/scripts/improve_parameters_using_gradient_descent_non_spsa.py
@@ -9,7 +9,7 @@ import numpy as np
 import pandas as pd
 
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     get_linker,
 )
 from uk_address_matcher.linking_model.training import get_settings_for_training
@@ -200,7 +200,7 @@ print(f"messy_count: {messy_count:,}, canonical_count: {canonical_count:,}")
 # Step 2: Clean data
 # -----------------------------------------------------------------------------
 
-df_messy_data_clean = clean_data_with_term_frequencies(messy_data, con=con_disk)
+df_messy_data_clean = prepare_data_for_matching(messy_data, con=con_disk)
 sql = """
 create table messy_data_clean as
 select * exclude (labels_filename) from df_messy_data_clean
@@ -208,7 +208,7 @@ select * exclude (labels_filename) from df_messy_data_clean
 con_disk.execute(sql)
 
 
-df_os_clean = clean_data_with_term_frequencies(con_disk.from_df(df_os), con=con_disk)
+df_os_clean = prepare_data_for_matching(con_disk.from_df(df_os), con=con_disk)
 sql = """
 create table os_clean as
 select * from df_os_clean

--- a/scripts/run_training.py
+++ b/scripts/run_training.py
@@ -7,7 +7,7 @@ import duckdb
 from secret_data.secrets import epc_addresses_path
 from splink import DuckDBAPI, Linker
 
-from uk_address_matcher import clean_data_with_term_frequencies
+from uk_address_matcher import prepare_data_for_matching
 from uk_address_matcher.linking_model.training import get_settings_for_training
 
 LIMIT = 100000000
@@ -29,7 +29,7 @@ con.execute(sql)
 epc_addresses = con.table("epc_addresses")
 
 
-epc_addresses_clean = clean_data_with_term_frequencies(epc_addresses, con=con)
+epc_addresses_clean = prepare_data_for_matching(epc_addresses, con=con)
 
 
 db_api = DuckDBAPI(connection=con)

--- a/tests/cleaning/test_postcode_extraction.py
+++ b/tests/cleaning/test_postcode_extraction.py
@@ -1,6 +1,6 @@
 import duckdb
 
-from uk_address_matcher.cleaning.pipelines import _clean_data_with_minimal_steps
+from uk_address_matcher.cleaning.pipelines import _clean_data_pre_term_frequencies
 
 
 def test_postcode_extraction_no_column_provided():
@@ -21,7 +21,7 @@ def test_postcode_extraction_no_column_provided():
             f"SELECT '1' as unique_id, '{input_address}' as address_concat"
         )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
         result = result_rel.select(
             "unique_id, original_address_concat, clean_full_address, postcode"
         ).fetchall()[0]
@@ -68,7 +68,7 @@ def test_postcode_extraction_with_column_provided():
             f"'{provided_postcode}' as postcode"
         )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
         result = result_rel.select(
             "unique_id, original_address_concat, clean_full_address, postcode"
         ).fetchall()[0]
@@ -127,7 +127,7 @@ def test_postcode_extraction_empty_column():
                 f"'{provided_postcode}' as postcode"
             )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
         result = result_rel.select(
             "unique_id, original_address_concat, clean_full_address, postcode"
         ).fetchall()[0]
@@ -169,7 +169,7 @@ def test_postcode_case_normalisation():
             f"SELECT '1' as unique_id, '{input_address}' as address_concat"
         )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
         result = result_rel.select("postcode").fetchall()[0]
 
         extracted_postcode = result[0]
@@ -185,7 +185,7 @@ def test_postcode_case_normalisation():
         "'sw1a 1aa' as postcode"
     )
 
-    result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+    result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
     result = result_rel.select("postcode").fetchall()[0]
 
     extracted_postcode = result[0]
@@ -214,7 +214,7 @@ def test_postcode_spacing_normalisation():
             f"'{input_postcode}' as postcode"
         )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
         result = result_rel.select("postcode").fetchall()[0]
 
         extracted_postcode = result[0]
@@ -239,7 +239,7 @@ def test_postcode_extraction_preserves_other_columns():
         """
     )
 
-    result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+    result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
 
     # Check that other columns are preserved
     assert "other_column" in result_rel.columns
@@ -271,7 +271,7 @@ def test_postcode_column_case_insensitive():
             """
         )
 
-        result_rel = _clean_data_with_minimal_steps(input_rel, connection)
+        result_rel = _clean_data_pre_term_frequencies(input_rel, connection)
 
         # Check that the column was renamed to lowercase 'postcode'
         assert "postcode" in result_rel.columns, (

--- a/tests/cleaning/test_ukam_address_id.py
+++ b/tests/cleaning/test_ukam_address_id.py
@@ -1,4 +1,4 @@
-from uk_address_matcher import clean_data_with_minimal_steps
+from uk_address_matcher import clean_data_pre_term_frequencies
 
 
 def test_duplicate_records_get_unique_ukam_address_id(duck_con):
@@ -17,7 +17,7 @@ def test_duplicate_records_get_unique_ukam_address_id(duck_con):
     test_data = duck_con.table("test_data")
 
     # Clean the data (single chunk to isolate the ID generation logic)
-    cleaned = clean_data_with_minimal_steps(test_data, con=duck_con, num_of_chunks=1)
+    cleaned = clean_data_pre_term_frequencies(test_data, con=duck_con, num_of_chunks=1)
 
     # Check that ukam_address_id column exists
     assert "ukam_address_id" in cleaned.columns, (
@@ -69,7 +69,7 @@ def test_chunking_with_duplicates_across_chunk_boundaries(duck_con):
     test_data = duck_con.table("test_data")
 
     # Process with 4 chunks (5 records each)
-    cleaned = clean_data_with_minimal_steps(test_data, con=duck_con, num_of_chunks=4)
+    cleaned = clean_data_pre_term_frequencies(test_data, con=duck_con, num_of_chunks=4)
 
     # Get all ukam_address_id values
     result = cleaned.select("ukam_address_id").fetchall()

--- a/tests/sql_pipeline/test_chunking.py
+++ b/tests/sql_pipeline/test_chunking.py
@@ -2,9 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
-from uk_address_matcher import clean_data_with_minimal_steps
+from uk_address_matcher import clean_data_pre_term_frequencies
 from uk_address_matcher.cleaning.chunking_strategies import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
 )
 
 
@@ -38,11 +38,11 @@ def test_chunking_yields_same_result_as_no_chunking(
     num_chunks = 5
 
     # Process without chunking (baseline)
-    baseline = clean_data_with_minimal_steps(fhrs_data, con=duck_con)
+    baseline = clean_data_pre_term_frequencies(fhrs_data, con=duck_con)
     baseline.to_table("baseline_rel")
 
     # Process with chunking
-    chunked = clean_data_with_minimal_steps(
+    chunked = clean_data_pre_term_frequencies(
         fhrs_data, con=duck_con, num_of_chunks=num_chunks
     )
     chunked.to_table("chunked_rel")
@@ -112,12 +112,10 @@ def test_chunking_yields_same_result_as_no_chunking(
 def test_clean_data_using_precomputed_rel_tok_freq(
     duck_con, fhrs_data, mock_chunk_size_1k
 ):
-    no_chunk_rel = clean_data_with_term_frequencies(fhrs_data, con=duck_con)
+    no_chunk_rel = prepare_data_for_matching(fhrs_data, con=duck_con)
     no_chunk_count = no_chunk_rel.count("*").fetchone()[0]
 
-    chunked_rel = clean_data_with_term_frequencies(
-        fhrs_data, con=duck_con, num_of_chunks=5
-    )
+    chunked_rel = prepare_data_for_matching(fhrs_data, con=duck_con, num_of_chunks=5)
     chunked_count = chunked_rel.count("*").fetchone()[0]
 
     # Confirm we get the expected number of records out
@@ -139,7 +137,7 @@ def test_token_rel_freq_arr_hist_consistent_across_chunks(
 ):
     """Verify token_rel_freq_arr_hist is identical irrespective of chunking strategy."""
     # Process without chunking (baseline)
-    no_chunk = clean_data_with_term_frequencies(
+    no_chunk = prepare_data_for_matching(
         fhrs_data,
         con=duck_con,
         num_of_chunks=1,
@@ -150,7 +148,7 @@ def test_token_rel_freq_arr_hist_consistent_across_chunks(
     )
 
     # Process with 5 chunks
-    chunked = clean_data_with_term_frequencies(
+    chunked = prepare_data_for_matching(
         fhrs_data,
         con=duck_con,
         num_of_chunks=5,
@@ -177,7 +175,7 @@ def test_numeric_term_frequency_columns_present_when_using_precomputed_tfs(
     - When use_data_specific_tfs=True: numeric TFs are computed from input data
     - When use_data_specific_tfs=False: numeric TFs are loaded from precomputed files
     """
-    result = clean_data_with_term_frequencies(
+    result = prepare_data_for_matching(
         fhrs_data,
         con=duck_con,
         num_of_chunks=1,

--- a/tests/test_accuracy_from_labels.py
+++ b/tests/test_accuracy_from_labels.py
@@ -7,7 +7,7 @@ from tests.utils import prepare_combined_test_data
 
 # Import necessary functions from the library
 from uk_address_matcher import (
-    clean_data_with_term_frequencies,
+    prepare_data_for_matching,
     evaluate_predictions_against_labels,
     get_linker,
     inspect_match_results_vs_labels,
@@ -49,12 +49,12 @@ def test_address_matching_workflow_runs():
     df_os_rel = canonical_addresses_raw
     messy_data_rel = messy_addresses_raw
 
-    df_messy_data_clean_rel = clean_data_with_term_frequencies(
+    df_messy_data_clean_rel = prepare_data_for_matching(
         messy_data_rel.project("unique_id, source_dataset, address_concat, postcode"),
         con=duckdb_con,
     )
 
-    df_os_clean_rel = clean_data_with_term_frequencies(
+    df_os_clean_rel = prepare_data_for_matching(
         df_os_rel.project("unique_id, source_dataset, address_concat, postcode"),
         con=duckdb_con,
     )

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -5,7 +5,7 @@ import pytest
 from splink import block_on
 
 from tests.utils import prepare_combined_test_data
-from uk_address_matcher import clean_data_with_term_frequencies, get_linker
+from uk_address_matcher import prepare_data_for_matching, get_linker
 from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
     improve_predictions_using_distinguishing_tokens,
 )
@@ -31,10 +31,8 @@ def run_matcher_workflow(messy_addresses, canonical_addresses, duckdb_con=None):
         duckdb_con = duckdb.connect(database=":memory:")
 
     # Clean the input data
-    messy_clean = clean_data_with_term_frequencies(messy_addresses, con=duckdb_con)
-    canonical_clean = clean_data_with_term_frequencies(
-        canonical_addresses, con=duckdb_con
-    )
+    messy_clean = prepare_data_for_matching(messy_addresses, con=duckdb_con)
+    canonical_clean = prepare_data_for_matching(canonical_addresses, con=duckdb_con)
 
     # Configure the linker
     columns_to_retain = ["original_address_concat", "true_match_id"]

--- a/tests/test_full_examples.py
+++ b/tests/test_full_examples.py
@@ -4,7 +4,7 @@ import subprocess
 import duckdb
 import pytest
 
-from uk_address_matcher import clean_data_with_term_frequencies
+from uk_address_matcher import prepare_data_for_matching
 
 
 def test_full_example():
@@ -54,7 +54,7 @@ def test_match_one(path, postcode):
         '{postcode}' as postcode
     """
     )
-    canon_data = clean_data_with_term_frequencies(canon_data, con=con)
+    canon_data = prepare_data_for_matching(canon_data, con=con)
     con.sql(
         f"COPY ({canon_data.sql_query()}) TO '{os.path.abspath(path)}' (FORMAT 'parquet')"
     )

--- a/tests/test_source_dataset.py
+++ b/tests/test_source_dataset.py
@@ -1,7 +1,7 @@
 import duckdb
 import pytest
 
-from uk_address_matcher import clean_data_with_term_frequencies, get_linker
+from uk_address_matcher import prepare_data_for_matching, get_linker
 
 
 def test_source_dataset_is_ignored():
@@ -47,8 +47,8 @@ def test_source_dataset_is_ignored():
     )
 
     # Clean the data
-    messy_clean = clean_data_with_term_frequencies(test_messy, con=con)
-    canonical_clean = clean_data_with_term_frequencies(test_canonical, con=con)
+    messy_clean = prepare_data_for_matching(test_messy, con=con)
+    canonical_clean = prepare_data_for_matching(test_canonical, con=con)
 
     # Verify source_dataset column is excluded from cleaned data
     assert "source_dataset" not in messy_clean.columns, (
@@ -137,7 +137,7 @@ def test_get_linker_raises_error_with_source_dataset():
         )
 
     # Clean the data to remove source_dataset
-    test_data_clean = clean_data_with_term_frequencies(test_data, con=con)
+    test_data_clean = prepare_data_for_matching(test_data, con=con)
 
     # Verify this works without error
     get_linker(

--- a/uk_address_matcher/__init__.py
+++ b/uk_address_matcher/__init__.py
@@ -1,8 +1,8 @@
 __version__ = "0.0.4"
 
 from uk_address_matcher.cleaning.chunking_strategies import (
-    clean_data_with_minimal_steps,
-    clean_data_with_term_frequencies,
+    clean_data_pre_term_frequencies,
+    prepare_data_for_matching,
 )
 from uk_address_matcher.linking_model.exact_matching import (
     StageName,
@@ -25,8 +25,8 @@ from uk_address_matcher.post_linkage.identify_distinguishing_tokens import (
 
 __all__ = [
     "get_linker",
-    "clean_data_with_term_frequencies",
-    "clean_data_with_minimal_steps",
+    "prepare_data_for_matching",
+    "clean_data_pre_term_frequencies",
     "calculate_match_metrics",
     "improve_predictions_using_distinguishing_tokens",
     "best_matches_with_distinguishability",

--- a/uk_address_matcher/cleaning/chunking_strategies.py
+++ b/uk_address_matcher/cleaning/chunking_strategies.py
@@ -8,7 +8,7 @@ from duckdb import DuckDBPyConnection, DuckDBPyRelation
 
 from uk_address_matcher.cleaning.pipelines import (
     _clean_data_using_precomputed_rel_tok_freq,
-    _clean_data_with_minimal_steps,
+    _clean_data_pre_term_frequencies,
     _create_term_frequency_tables,
 )
 from uk_address_matcher.sql_pipeline.helpers import _uid
@@ -78,7 +78,7 @@ def _should_use_data_specific_term_frequencies(
         return total_records >= 500_000
 
 
-def clean_data_with_minimal_steps(
+def clean_data_pre_term_frequencies(
     address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
     num_of_chunks: int = 10,
@@ -123,7 +123,7 @@ def clean_data_with_minimal_steps(
         """)
 
         # Process the chunk without address ID, applying debug options only on first iteration
-        processed_chunk = _clean_data_with_minimal_steps(
+        processed_chunk = _clean_data_pre_term_frequencies(
             chunk,
             con,
             debug_options=debug_options if chunk_index == 0 else None,
@@ -151,7 +151,7 @@ def clean_data_with_minimal_steps(
 # 2. At the end of each chunk, accumulate token counts to compute global term frequencies
 # 3. Use computed term frequencies to populate term frequency fields in cleaned data and
 #   finally apply QUEUE_POST_TF
-def clean_data_with_term_frequencies(
+def prepare_data_for_matching(
     address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
     num_of_chunks: int = 10,
@@ -160,21 +160,8 @@ def clean_data_with_term_frequencies(
     *,
     debug_options: Optional[DebugOptions] = None,
 ) -> DuckDBPyRelation:
-    """Clean address data using term frequencies computed from the input data.
+    """Prepare address data for matching
 
-    Computes relative token frequencies directly from the input address table
-    and applies them during cleaning. This approach ensures term frequencies
-    reflect the specific input dataset, making it ideal for single-run analyses
-    or when you have a representative sample.
-
-    The pipeline applies all stages from QUEUE_PRE_TF + term frequency stage + QUEUE_POST_TF
-    (see pipelines.py for full stage list). Post-TF stages include:
-    - Moving common end tokens to a dedicated field
-    - Identifying first unusual tokens
-    - Separating distinguishing unusual tokens
-
-    When chunking is enabled, term frequencies are computed once across the full dataset,
-    then each chunk is processed independently and results are unioned.
 
     Args:
         address_table: Input address relation with standard schema.
@@ -200,7 +187,7 @@ def clean_data_with_term_frequencies(
     uid = _uid()
 
     # Clean data in chunks (without term frequencies)
-    cleaned_address_table = clean_data_with_minimal_steps(
+    cleaned_address_table = clean_data_pre_term_frequencies(
         address_table, con, num_of_chunks=num_of_chunks, debug_options=debug_options
     )
 
@@ -275,6 +262,6 @@ def clean_data_with_term_frequencies(
 
 
 __all__ = [
-    "clean_data_with_minimal_steps",
-    "clean_data_with_term_frequencies",
+    "clean_data_pre_term_frequencies",
+    "prepare_data_for_matching",
 ]

--- a/uk_address_matcher/cleaning/pipelines.py
+++ b/uk_address_matcher/cleaning/pipelines.py
@@ -113,7 +113,7 @@ QUEUE_POST_TF = [
 ]
 
 
-def _clean_data_with_minimal_steps(
+def _clean_data_pre_term_frequencies(
     address_table: DuckDBPyRelation,
     con: DuckDBPyConnection,
     *,
@@ -125,8 +125,8 @@ def _clean_data_with_minimal_steps(
         con,
         input_rel=address_table,
         stage_specs=QUEUE_PRE_TF,
-        pipeline_name="Clean data with minimal steps",
-        pipeline_description="A minimal cleaning pipeline without term frequencies",
+        pipeline_name="Clean data pre term frequencies",
+        pipeline_description="The cleaning pipeline pre the term frequency steps",
     )
     result = pipeline.run(debug_options)
 


### PR DESCRIPTION
This doesn't change any logic, just rename the functions for clarity