### PR TITLE
Revert changes to postcode null level

### DIFF
--- a/uk_address_matcher/data/splink_model.json
+++ b/uk_address_matcher/data/splink_model.json
@@ -75,10 +75,6 @@
             "sql_dialect": "duckdb"
         },
         {
-            "blocking_rule": "l.\"postcode\" = r.\"postcode\"",
-            "sql_dialect": "duckdb"
-        },
-        {
             "blocking_rule": "l.exploding_unique_ids = r.exploding_unique_ids",
             "sql_dialect": "duckdb",
             "arrays_to_explode": [
@@ -726,11 +722,15 @@
             "output_column_name": "postcode",
             "comparison_levels": [
                 {
-                    "sql_condition": "postcode_l IS NULL OR postcode_r IS NULL",
+                    "sql_condition": "postcode_l IS NULL AND postcode_r IS NULL",
                     "label_for_charts": "Null",
-                    "fix_m_probability": false,
-                    "fix_u_probability": false,
-                    "is_null_level": true,
+                    "is_null_level": true
+                },
+                {
+                    "sql_condition": "postcode_r IS NULL",
+                    "label_for_charts": "Postcode missing from messy table",
+                    "fix_m_probability": true,
+                    "fix_u_probability": true,
                     "m_probability": 1024,
                     "u_probability": 1
                 },

--- a/uk_address_matcher/linking_model/training.py
+++ b/uk_address_matcher/linking_model/training.py
@@ -723,9 +723,17 @@ postcode_comparison = {
     "output_column_name": "postcode",
     "comparison_levels": [
         {
-            "sql_condition": '"postcode_l" IS NULL OR "postcode_r" IS NULL',
+            "sql_condition": "postcode_l IS NULL AND postcode_r IS NULL",
             "label_for_charts": "Null",
             "is_null_level": True,
+        },
+        {
+            "sql_condition": "postcode_r IS NULL",
+            "label_for_charts": "Postcode missing from messy table",
+            "fix_m_probability": True,
+            "fix_u_probability": True,
+            "m_probability": 1024,
+            "u_probability": 1,
         },
         {
             "sql_condition": "postcode_l = postcode_r",


### PR DESCRIPTION
These attribute a higher weight to any messy address matches  where the postcode in the messy address is null.

The rationale is that it's effectively impossible to get to a high match weight if you're missing a postcode.  It's a bit of a hack.  In reality, user would be better running matching twice: once on the messy address without postcode and one on the messy addresses with postcode, and picking different matching thresholds

Reverts relevant changes in:
https://github.com/moj-analytical-services/uk_address_matcher/pull/199