### PR TITLE
build(ci): add concurrency rules to stop stale runs

### DIFF
--- a/.github/workflows/accuracy_from_labels_dataset.yml
+++ b/.github/workflows/accuracy_from_labels_dataset.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-address-matcher:
     runs-on: ubuntu-latest

--- a/.github/workflows/edge_cases_github_comment.yml
+++ b/.github/workflows/edge_cases_github_comment.yml
@@ -12,6 +12,10 @@ permissions:
   pull-requests: write
   issues: write # PR comments are issue comments under the hood; this avoids permission surprises
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-address-matcher:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint_and_format.yml
+++ b/.github/workflows/lint_and_format.yml
@@ -6,6 +6,10 @@ on:
       - "**/*.py"
       - "pyproject.toml"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint with Ruff

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -9,6 +9,10 @@ permissions:
   actions: read
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -15,6 +15,10 @@ on:
       - "pyproject.toml"
       - "uv.lock"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-pytest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds concurrency rules for our CI to automatically stop stale runs.