### PR TITLE
feat: add stage timings at debug level for monitoring

### DIFF
--- a/tests/test_address_matcher.py
+++ b/tests/test_address_matcher.py
@@ -365,12 +365,9 @@ def test_stage_repr_is_concise_and_informative():
     assert peeled_repr.startswith("PeeledAddressStage()")
     assert "\n  Purpose:" in peeled_repr
     assert (
-        "Deterministic matching after peeling common UK locality suffixes."
-        in peeled_repr
+        "Deterministic matching after peeling common UK locality suffixes." in peeled_repr
     )  # noqa: E501
-    assert (
-        "\n  Import:  from uk_address_matcher import PeeledAddressStage" in peeled_repr
-    )
+    assert "\n  Import:  from uk_address_matcher import PeeledAddressStage" in peeled_repr
 
     assert splink_repr.startswith("SplinkStage(final_match_weight_threshold=7.0)")
     assert "\n  Purpose:" in splink_repr
@@ -391,9 +388,7 @@ def test_stage_repr_is_concise_and_informative():
 def test_available_stages_prints_human_guidance():
     text = str(AddressMatcher.available_stages())
 
-    assert text.startswith(
-        "Available matching stages (import from uk_address_matcher):"
-    )
+    assert text.startswith("Available matching stages (import from uk_address_matcher):")
     assert "ExactMatchStage" in text
     assert "PeeledAddressStage" in text
     assert "SplinkStage" in text
@@ -417,14 +412,11 @@ def test_matching_does_not_leak_unnamed_relations(con, canonical_data, messy_dat
     matcher.match()
 
     table_names = [
-        row[0]
-        for row in con.execute("SELECT table_name FROM duckdb_tables()").fetchall()
+        row[0] for row in con.execute("SELECT table_name FROM duckdb_tables()").fetchall()
     ]
 
     unnamed_relations = [
-        name
-        for name in table_names
-        if re.fullmatch(r"unnamed_relation_[0-9a-f]+", name)
+        name for name in table_names if re.fullmatch(r"unnamed_relation_[0-9a-f]+", name)
     ]
     assert not unnamed_relations, (
         "Unexpected unnamed_relation tables leaked into the connection: "
@@ -432,9 +424,7 @@ def test_matching_does_not_leak_unnamed_relations(con, canonical_data, messy_dat
     )
 
     splink_numeric_tf = [
-        name
-        for name in table_names
-        if name.startswith("__splink__df_tf_numeric_token_")
+        name for name in table_names if name.startswith("__splink__df_tf_numeric_token_")
     ]
     normalised = {_normalise_hash_suffix(name) for name in splink_numeric_tf}
     assert len(normalised) == len(splink_numeric_tf), (
@@ -442,9 +432,7 @@ def test_matching_does_not_leak_unnamed_relations(con, canonical_data, messy_dat
         f"raw={sorted(splink_numeric_tf)}, normalised={sorted(normalised)}"
     )
 
-    root_tables = [
-        name for name in table_names if re.fullmatch(r"root_[a-z0-9]+", name)
-    ]
+    root_tables = [name for name in table_names if re.fullmatch(r"root_[a-z0-9]+", name)]
     assert len(root_tables) <= 2, (
         "Expected at most two root_* tables for canonical/messy inputs, "
         f"found {len(root_tables)}: {sorted(root_tables)}"
@@ -453,9 +441,7 @@ def test_matching_does_not_leak_unnamed_relations(con, canonical_data, messy_dat
     processed_tables = [
         name
         for name in table_names
-        if re.fullmatch(
-            r"(?:__ukam__|ukam__)processed_(messy|canonical)_[a-z0-9]+", name
-        )
+        if re.fullmatch(r"(?:__ukam__|ukam__)processed_(messy|canonical)_[a-z0-9]+", name)
     ]
     assert len(processed_tables) == 2, (
         "Expected one processed table each for messy/canonical inputs, "

--- a/uk_address_matcher/linking_model/matching/runner.py
+++ b/uk_address_matcher/linking_model/matching/runner.py
@@ -114,9 +114,7 @@ def _build_final_output(
         "canonical_ukam_address_id",
         "match_reason",
     }
-    additional_columns = [
-        column for column in results_columns if column not in excluded
-    ]
+    additional_columns = [column for column in results_columns if column not in excluded]
     additional_projection = "".join(
         f",\n            results.{column}" for column in additional_columns
     )


### PR DESCRIPTION
Adds a basic timer config to each of our stages at the debug level:
> DEBUG:uk_address_matcher:Stage 'peeled_address' completed in 0m 00s.

The timer only reports minutes and seconds. I don't imagine we'll need more granularity than that.