### PR TITLE
feat: implement ukam_label validation decorator

### DIFF
--- a/tests/test_threshold_analysis.py
+++ b/tests/test_threshold_analysis.py
@@ -30,6 +30,30 @@ def _run_threshold_metrics(
     return {row[cols.index("truth_threshold")]: dict(zip(cols, row)) for row in rows}
 
 
+def _make_result_without_ukam_label() -> MatchResult:
+    con = duckdb.connect()
+    con.register(
+        "m",
+        pa.Table.from_pylist(
+            [
+                {
+                    "unique_id": "a",
+                    "resolved_canonical_id": "1",
+                    "match_weight": 12.0,
+                    "match_reason": "splink: probabilistic match",
+                }
+            ]
+        ),
+    )
+    con.register("c", pa.Table.from_pylist([{"unique_id": "1"}]))
+
+    return MatchResult(
+        _relation=con.table("m"),
+        con=con,
+        _canonical_relation=con.table("c"),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -342,6 +366,43 @@ def test_accuracy_analysis_rejects_roc_output_type():
 
     with pytest.raises(ValueError, match="Invalid output_type"):
         result.accuracy_analysis(output_type="roc")
+
+
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("_accuracy_table", {}),
+        (
+            "_compare_splink_model_results",
+            {
+                "baseline_match_weight": 10.0,
+                "precision_at_metrics": None,
+            },
+        ),
+    ],
+)
+def test_match_result_analysis_methods_require_ukam_label(method_name, kwargs):
+    result = _make_result_without_ukam_label()
+    method = getattr(result, method_name)
+
+    with pytest.raises(
+        ValueError,
+        match=f"{method_name} requires a 'ukam_label' column",
+    ):
+        method(**kwargs)
+
+
+def test_compare_splink_model_results_requires_ukam_label_without_top_k_metrics():
+    result = _make_result_without_ukam_label()
+
+    with pytest.raises(
+        ValueError,
+        match="_compare_splink_model_results requires a 'ukam_label' column",
+    ):
+        result._compare_splink_model_results(
+            baseline_match_weight=10.0,
+            precision_at_metrics=None,
+        )
 
 
 def test_accuracy_table_supports_splink_threshold_override():

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -10,6 +10,7 @@ from uk_address_matcher.analysis.accuracy_sql import (
     wrong_match_rate_sql,
 )
 from uk_address_matcher.analysis.sql_helpers import sql_literal
+from uk_address_matcher.analysis.validation import requires_ukam_label
 from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
 if TYPE_CHECKING:
@@ -40,6 +41,7 @@ def resolve_splink_threshold_match_weight(
     )
 
 
+@requires_ukam_label("relation", function_name="_accuracy_table")
 def build_accuracy_table(
     con: duckdb.DuckDBPyConnection,
     relation: duckdb.DuckDBPyRelation,
@@ -47,11 +49,6 @@ def build_accuracy_table(
     splink_match_weight_threshold: float | None = None,
     splink_match_probability_threshold: float | None = None,
 ) -> duckdb.DuckDBPyRelation:
-    if "ukam_label" not in relation.columns:
-        raise ValueError(
-            "_accuracy_table requires a 'ukam_label' column in the match results. "
-            "Add a ground-truth label column to the input addresses_to_match data."
-        )
 
     threshold_match_weight = resolve_splink_threshold_match_weight(
         splink_match_weight_threshold=splink_match_weight_threshold,

--- a/uk_address_matcher/analysis/splink_comparison_metrics.py
+++ b/uk_address_matcher/analysis/splink_comparison_metrics.py
@@ -18,6 +18,7 @@ from uk_address_matcher.analysis.sql_helpers import (
     signed_pp_delta_sql,
     sql_literal,
 )
+from uk_address_matcher.analysis.validation import requires_ukam_label
 
 if TYPE_CHECKING:
     import duckdb
@@ -167,10 +168,6 @@ def _build_top_k_scenario_metrics_relation(
     scenario_label: str,
     precision_at_cutoffs: list[int],
 ) -> duckdb.DuckDBPyRelation:
-    if "ukam_label" not in labelled_relation.columns:
-        raise ValueError(
-            "Top-k analysis requires a 'ukam_label' column in the match results."
-        )
     if "match_weight" not in predictions_relation.columns:
         raise ValueError(
             "Splink predictions table is missing required column 'match_weight'."
@@ -726,6 +723,7 @@ def _build_top_k_sql_fragments(
     )
 
 
+@requires_ukam_label("relation", function_name="_compare_splink_model_results")
 def build_splink_model_comparison(
     con: duckdb.DuckDBPyConnection,
     relation: duckdb.DuckDBPyRelation,

--- a/uk_address_matcher/analysis/validation.py
+++ b/uk_address_matcher/analysis/validation.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import inspect
+from functools import wraps
+from typing import TYPE_CHECKING, Callable, ParamSpec, TypeVar
+
+if TYPE_CHECKING:
+    import duckdb
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+_UKAM_LABEL_ERROR_SUFFIX = (
+    "requires a 'ukam_label' column in the match results. "
+    "Add a ground-truth label column to the input addresses_to_match data."
+)
+
+
+def ensure_ukam_label_column(
+    relation: duckdb.DuckDBPyRelation,
+    *,
+    function_name: str,
+) -> None:
+    """Raise a consistent error when ukam_label is unavailable."""
+    if "ukam_label" not in relation.columns:
+        raise ValueError(f"{function_name} {_UKAM_LABEL_ERROR_SUFFIX}")
+
+
+def requires_ukam_label(
+    relation_arg_name: str,
+    *,
+    function_name: str | None = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Decorator enforcing ukam_label availability for a relation argument."""
+
+    def decorator(func: Callable[P, R]) -> Callable[P, R]:
+        signature = inspect.signature(func)
+        name_for_error = function_name or func.__name__
+
+        @wraps(func)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+            bound = signature.bind_partial(*args, **kwargs)
+            relation = bound.arguments.get(relation_arg_name)
+            if relation is None:
+                raise TypeError(
+                    f"Missing required relation argument '{relation_arg_name}' "
+                    f"for {func.__name__}."
+                )
+            ensure_ukam_label_column(relation, function_name=name_for_error)
+            return func(*args, **kwargs)
+
+        return wrapped
+
+    return decorator

--- a/uk_address_matcher/post_linkage/match_result/result.py
+++ b/uk_address_matcher/post_linkage/match_result/result.py
@@ -272,6 +272,8 @@ class MatchResult:
         contains the confusion-matrix counts (tp, tn, fp, fn) plus the derived
         rates (tp_rate, fp_rate, precision, recall, f1).
 
+        Requires a ``ukam_label`` column in the match results relation.
+
         Important semantics: this uses top-1 outcome evaluation.  Wrong-ID rows
         are false positives at their emitted score; they are not score-floored.
         Recall is derived from true positives as ``TP/P`` (equivalently
@@ -304,11 +306,6 @@ class MatchResult:
             the canonical dataset; it is used to derive ``tn``, ``tn_rate``,
             and ``fp_rate``.
         """
-        if "ukam_label" not in self._relation.columns:
-            raise ValueError(
-                "accuracy_data requires a 'ukam_label' column in the match results. "
-                "Add a ground-truth label column to the input addresses_to_match data."
-            )
         if self._canonical_relation is None:
             raise ValueError(
                 "accuracy_data requires access to the canonical dataset to determine "
@@ -348,7 +345,7 @@ class MatchResult:
         """Generate an accuracy chart or table from labelled match results.
 
         Mirrors Splink's ``linker.evaluation.accuracy_analysis_from_labels_table``
-        API.  Requires a ``ukam_label`` column in the input addresses.
+        API. Requires a ``ukam_label`` column in the input addresses.
 
         Args:
             match_weight_round_to_nearest: Round splink match weights to this
@@ -431,6 +428,8 @@ class MatchResult:
         Returns two tables:
         - headline_table: key operational and quality metrics per threshold
         - delta_table: changes versus the baseline threshold
+
+        Requires a ``ukam_label`` column in the match results relation.
 
         ``human_readable=False`` returns machine-friendly numeric delta fields.
         """


### PR DESCRIPTION
A simple validator for confirming that the input relation contains a ukam_label column before running any accuracy analysis functions.