### PR TITLE
fix: properly report unmatched records in accuracy table

### DIFF
--- a/benchmarking/comparisons/console_report.py
+++ b/benchmarking/comparisons/console_report.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -97,8 +97,8 @@ def _format_run_timestamp(value: str | None) -> str:
         return value
 
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
-    utc_time = parsed.astimezone(UTC)
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    utc_time = parsed.astimezone(timezone.utc)
     return utc_time.strftime("%Y-%m-%d %H:%M:%S UTC")
 
 

--- a/benchmarking/comparisons/markdown_summary.py
+++ b/benchmarking/comparisons/markdown_summary.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -87,9 +87,9 @@ def _format_utc_timestamp(value: str | None) -> str:
         return value
 
     if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=UTC)
+        parsed = parsed.replace(tzinfo=timezone.utc)
 
-    return parsed.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    return parsed.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
 
 
 def _markdown_table(headers: list[str], rows: list[list[str]]) -> str:

--- a/benchmarking/insights/run_persistence.py
+++ b/benchmarking/insights/run_persistence.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 from collections.abc import Sequence
 from dataclasses import fields, is_dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
@@ -156,7 +156,7 @@ def _safe_path_segment(value: str) -> str:
 
 
 def _now_utc_iso() -> str:
-    return datetime.now(UTC).isoformat()
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _normalise_value(value: Any) -> Any:
@@ -415,17 +415,17 @@ def _records_to_hash_records(
 
 def _parse_created_at(value: str | None) -> datetime:
     if not value:
-        return datetime.min.replace(tzinfo=UTC)
+        return datetime.min.replace(tzinfo=timezone.utc)
 
     normalised = value.replace("Z", "+00:00")
     try:
         parsed = datetime.fromisoformat(normalised)
     except ValueError:
-        return datetime.min.replace(tzinfo=UTC)
+        return datetime.min.replace(tzinfo=timezone.utc)
 
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=UTC)
-    return parsed.astimezone(UTC)
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _sorted_dataset_runs(

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -64,7 +64,7 @@ def build_accuracy_table(
     splink_reason_sql = f"'{splink_value}'::ENUM {enum_values}"
     precision_sql = ratio_sql(
         "correct_matches",
-        "rows_matched_in_stage",
+        "matched_row_count",
         when_zero_sql="NULL::DOUBLE",
     )
     recall_sql = ratio_sql(
@@ -74,11 +74,11 @@ def build_accuracy_table(
     )
     f1_sql = f1_from_counts_sql(
         tp_sql="correct_matches",
-        fp_sql="(rows_matched_in_stage - correct_matches)",
+        fp_sql="(matched_row_count - correct_matches)",
         fn_sql="((SELECT total_input_rows FROM totals) - correct_matches)",
     )
     wrong_match_rate_expr = wrong_match_rate_sql(
-        rows_matched_sql="rows_matched_in_stage",
+        rows_matched_sql="matched_row_count",
         correct_matches_sql="correct_matches",
     )
     correct_share_expr = correct_share_of_total_sql(
@@ -92,6 +92,8 @@ def build_accuracy_table(
             SELECT
                 CASE
                     WHEN m.match_reason IS NULL THEN 'unmatched'
+                    WHEN m.match_reason = {splink_reason_sql}
+                        AND NOT ({splink_accepted_sql}) THEN 'unmatched'
                     WHEN split_part(m.match_reason::VARCHAR, ':', 1) = 'exact'
                         THEN 'exact_matches'
                     ELSE split_part(m.match_reason::VARCHAR, ':', 1)
@@ -119,16 +121,32 @@ def build_accuracy_table(
                     WHEN GROUPING(stage) = 1 THEN 'overall'
                     ELSE stage
                 END AS stage,
-                SUM(CASE WHEN is_matched THEN 1 ELSE 0 END) AS rows_matched_in_stage,
+                COUNT(*) AS stage_row_count,
+                SUM(CASE WHEN is_matched THEN 1 ELSE 0 END) AS matched_row_count,
                 SUM(CASE WHEN is_correct THEN 1 ELSE 0 END) AS correct_matches
             FROM scored
             GROUP BY GROUPING SETS ((stage), ())
+        ),
+        display_rows AS (
+            SELECT
+                stage,
+                CASE
+                    WHEN stage = 'unmatched' THEN stage_row_count
+                    ELSE matched_row_count
+                END AS rows_matched_in_stage,
+                matched_row_count,
+                correct_matches,
+                CASE
+                    WHEN stage = 'unmatched' THEN 0
+                    ELSE matched_row_count - correct_matches
+                END AS wrong_matches
+            FROM all_rows
         )
         SELECT
             stage,
             rows_matched_in_stage,
             correct_matches,
-            rows_matched_in_stage - correct_matches AS wrong_matches,
+            wrong_matches,
             ROUND(
                 {precision_sql},
                 6
@@ -149,7 +167,7 @@ def build_accuracy_table(
                 {f1_sql},
                 6
             ) AS f1
-        FROM all_rows
+        FROM display_rows
         ORDER BY
             rows_matched_in_stage DESC,
             stage


### PR DESCRIPTION
Fixes an issue where our unmatched records were always reported a 0. The accuracy table should now accurately report how many unmatched records we had in the system.