### PR TITLE
feat: update persistence hashes to be time based

### DIFF
--- a/benchmarking/comparisons/comparison_artifacts.py
+++ b/benchmarking/comparisons/comparison_artifacts.py
@@ -58,6 +58,9 @@ def _build_compact_table_sql(
     ),
     metadata AS (
         SELECT
+            max(CASE WHEN run_type = 'baseline' THEN run_id END) AS baseline_run_id,
+            max(CASE WHEN run_type = 'comparison' THEN run_id END)
+                AS comparison_run_id,
             max(CASE WHEN run_type = 'baseline' THEN run_hash END) AS baseline_hash,
             max(CASE WHEN run_type = 'comparison' THEN run_hash END)
                 AS comparison_hash
@@ -66,7 +69,10 @@ def _build_compact_table_sql(
     baseline_row AS (
         SELECT
             'baseline' AS version,
-            (SELECT baseline_hash FROM metadata) AS version_hash,
+            coalesce(
+                (SELECT baseline_run_id FROM metadata),
+                (SELECT baseline_hash FROM metadata)
+            ) AS run_id,
             string_agg(
                 stage,
                 ' | '
@@ -80,7 +86,10 @@ def _build_compact_table_sql(
     comparison_row AS (
         SELECT
             'comparison' AS version,
-            (SELECT comparison_hash FROM metadata) AS version_hash,
+            coalesce(
+                (SELECT comparison_run_id FROM metadata),
+                (SELECT comparison_hash FROM metadata)
+            ) AS run_id,
             string_agg(
                 stage,
                 ' | '
@@ -93,7 +102,7 @@ def _build_compact_table_sql(
     )
     SELECT
         version,
-        version_hash,
+        run_id,
         stages_run,
         {output_columns_sql},
         run_timestamp
@@ -110,6 +119,7 @@ def _build_run_comparison_row(
     *,
     row: dict[str, Any],
     run_type: str,
+    run_id: str,
     run_hash: str,
     git_commit_hash: str | None,
     baseline_hash: str,
@@ -119,6 +129,7 @@ def _build_run_comparison_row(
 ) -> dict[str, Any]:
     return {
         "run_type": run_type,
+        "run_id": run_id,
         "run_hash": run_hash,
         "git_commit_hash": git_commit_hash,
         "baseline_hash": baseline_hash,
@@ -132,6 +143,8 @@ def _build_comparison_rows(
     *,
     baseline_rows: list[dict[str, Any]],
     current_rows: list[dict[str, Any]],
+    baseline_run_id: str,
+    current_run_id: str,
     baseline_hash: str,
     current_hash: str,
     baseline_git_commit_hash: str | None,
@@ -158,6 +171,7 @@ def _build_comparison_rows(
                 _build_run_comparison_row(
                     row=baseline,
                     run_type="baseline",
+                    run_id=baseline_run_id,
                     run_hash=baseline_hash,
                     git_commit_hash=baseline_git_commit_hash,
                     baseline_hash=baseline_hash,
@@ -168,6 +182,7 @@ def _build_comparison_rows(
                 _build_run_comparison_row(
                     row=current,
                     run_type="comparison",
+                    run_id=current_run_id,
                     run_hash=current_hash,
                     git_commit_hash=current_git_commit_hash,
                     baseline_hash=baseline_hash,
@@ -443,6 +458,8 @@ def build_accuracy_comparison_rows(
     *,
     baseline_rows: list[dict[str, Any]],
     current_rows: list[dict[str, Any]],
+    baseline_run_id: str,
+    current_run_id: str,
     baseline_hash: str,
     current_hash: str,
     baseline_git_commit_hash: str | None = None,
@@ -463,6 +480,8 @@ def build_accuracy_comparison_rows(
     return _build_comparison_rows(
         baseline_rows=baseline_rows,
         current_rows=current_rows,
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         baseline_git_commit_hash=baseline_git_commit_hash,
@@ -475,6 +494,8 @@ def build_stage_diagnostics_comparison_rows(
     *,
     baseline_rows: list[dict[str, Any]],
     current_rows: list[dict[str, Any]],
+    baseline_run_id: str,
+    current_run_id: str,
     baseline_hash: str,
     current_hash: str,
     baseline_git_commit_hash: str | None = None,
@@ -495,6 +516,8 @@ def build_stage_diagnostics_comparison_rows(
     return _build_comparison_rows(
         baseline_rows=baseline_rows,
         current_rows=current_rows,
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         baseline_git_commit_hash=baseline_git_commit_hash,
@@ -535,6 +558,8 @@ def _build_notes(overall_delta: dict[str, float | None]) -> list[str]:
 
 def build_comparison_summary(
     *,
+    baseline_run_id: str,
+    current_run_id: str,
     baseline_hash: str,
     current_hash: str,
     baseline_accuracy_rows: list[dict[str, Any]],
@@ -600,6 +625,8 @@ def build_comparison_summary(
         }
 
     summary = BenchmarkComparisonSummary(
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         overall_delta=overall_delta,
@@ -617,6 +644,8 @@ def build_comparison_summary(
     summary_path.write_text(
         json.dumps(
             {
+                "baseline_run_id": summary.baseline_run_id,
+                "current_run_id": summary.current_run_id,
                 "baseline_hash": summary.baseline_hash,
                 "current_hash": summary.current_hash,
                 "overall_delta": summary.overall_delta,
@@ -635,6 +664,8 @@ def build_comparison_summary(
         _write_comparison_markdown_summary(
             path=markdown_report_path,
             dataset_label=dataset_label,
+            baseline_run_id=baseline_run_id,
+            current_run_id=current_run_id,
             baseline_hash=baseline_hash,
             current_hash=current_hash,
             baseline_git_commit_hash=baseline_git_commit_hash,

--- a/benchmarking/comparisons/console_report.py
+++ b/benchmarking/comparisons/console_report.py
@@ -148,8 +148,10 @@ def print_comparison_report(
     comparison_ts = _format_run_timestamp(comparison_ts_raw)
 
     print("Comparison completed")
-    print(f"- current_hash: {comparison.current_hash}")
-    print(f"- baseline_hash: {comparison.baseline_hash}")
+    print(f"- current_run_id: {comparison.current_run_id}")
+    print(f"- baseline_run_id: {comparison.baseline_run_id}")
+    print(f"- current_dedupe_hash: {comparison.current_hash}")
+    print(f"- baseline_dedupe_hash: {comparison.baseline_hash}")
     print(f"- summary: {_absolute_path(comparison.summary_path)}")
     if comparison.markdown_report_path is not None:
         print(f"- pr_markdown: {_absolute_path(comparison.markdown_report_path)}")

--- a/benchmarking/comparisons/markdown_summary.py
+++ b/benchmarking/comparisons/markdown_summary.py
@@ -537,6 +537,8 @@ def write_comparison_markdown_summary(
     *,
     path: Path,
     dataset_label: str | None,
+    baseline_run_id: str,
+    current_run_id: str,
     baseline_hash: str,
     current_hash: str,
     baseline_git_commit_hash: str | None,
@@ -617,23 +619,31 @@ def write_comparison_markdown_summary(
 
     markdown = "\n".join(
         [
-            f"# Benchmark Comparison: {baseline_hash} vs {current_hash}",
+            f"# Benchmark Comparison: {baseline_run_id} vs {current_run_id}",
             "",
             f"Dataset: {_format_optional_text(dataset_label)}",
             "",
             "## Runs",
             "",
             _markdown_table(
-                ["Run", "Hash", "Git commit", "Created at (UTC)"],
+                [
+                    "Run",
+                    "Run ID",
+                    "Internal dedupe hash",
+                    "Git commit",
+                    "Created at (UTC)",
+                ],
                 [
                     [
                         "Baseline",
+                        baseline_run_id,
                         baseline_hash,
                         _format_optional_text(baseline_git_commit_hash),
                         _format_utc_timestamp(baseline_created_at_utc),
                     ],
                     [
                         "Current",
+                        current_run_id,
                         current_hash,
                         _format_optional_text(current_git_commit_hash),
                         _format_utc_timestamp(current_created_at_utc),

--- a/benchmarking/insights/__init__.py
+++ b/benchmarking/insights/__init__.py
@@ -6,6 +6,7 @@ from benchmarking.insights.reporting import (
 )
 from benchmarking.insights.run_persistence import (
     compare_persisted_runs,
+    generate_benchmark_run_id,
     persist_benchmark_run,
 )
 from benchmarking.insights.summary import fetch_overall_summary
@@ -23,6 +24,7 @@ __all__ = [
     "build_dataset_diagnostics",
     "fetch_overall_summary",
     "compare_persisted_runs",
+    "generate_benchmark_run_id",
     "persist_benchmark_run",
     "print_benchmark_summary",
     "print_diagnostics",

--- a/benchmarking/insights/reporting.py
+++ b/benchmarking/insights/reporting.py
@@ -150,10 +150,11 @@ def print_run_persistence_summary(results: list[BenchmarkRunResult]) -> None:
 
         print(f"\nDataset: {result.dataset_key}")
         print(
-            f"hash={persisted.run_hash} "
+            f"run_id={persisted.run_id} "
             f"deduplicated={persisted.deduplicated} "
             f"manifest={_display_path(persisted.manifest_path)}"
         )
+        print(f"internal_dedupe_hash={persisted.run_hash}")
         if persisted.comparison_warning is not None:
             print(f"Warning: {persisted.comparison_warning}")
         if persisted.comparison is None:
@@ -162,9 +163,10 @@ def print_run_persistence_summary(results: list[BenchmarkRunResult]) -> None:
         comparison = persisted.comparison
         summary_path = _display_path(comparison.summary_path)
         print(
-            "Compared against baseline "
-            f"{comparison.baseline_hash}. Summary: {summary_path}"
+            "Compared against baseline run_id "
+            f"{comparison.baseline_run_id}. Summary: {summary_path}"
         )
+        print(f"Baseline internal dedupe hash: {comparison.baseline_hash}")
         if comparison.markdown_report_path is not None:
             print(f"PR markdown: {_display_path(comparison.markdown_report_path)}")
         if comparison.notes:

--- a/benchmarking/insights/run_persistence.py
+++ b/benchmarking/insights/run_persistence.py
@@ -155,8 +155,14 @@ def _safe_path_segment(value: str) -> str:
     return safe or "unknown_dataset"
 
 
-def _now_utc_iso() -> str:
-    return datetime.now(timezone.utc).isoformat()
+def generate_benchmark_run_id(*, at: datetime | None = None) -> str:
+    timestamp = at or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=timezone.utc)
+    else:
+        timestamp = timestamp.astimezone(timezone.utc)
+    seed = timestamp.strftime("%Y%m%dT%H%M%S%fZ")
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
 
 
 def _normalise_value(value: Any) -> Any:
@@ -403,6 +409,29 @@ def _build_group_key(*, dataset_key: str, stage_fingerprint: str) -> str:
     return f"{dataset_key}:{stage_fingerprint}"
 
 
+def _normalise_run_id(*, run_id: str | None, fallback_at: datetime) -> str:
+    if run_id is None:
+        return generate_benchmark_run_id(at=fallback_at)
+
+    normalised = run_id.strip()
+    if not normalised:
+        return generate_benchmark_run_id(at=fallback_at)
+    return normalised
+
+
+def _run_info_run_id(
+    run_info: dict[str, Any],
+    *,
+    fallback_hash: str | None = None,
+) -> str | None:
+    run_id = run_info.get("run_id")
+    if run_id is None:
+        return fallback_hash
+
+    normalised = str(run_id).strip()
+    return normalised or fallback_hash
+
+
 def _records_to_hash_records(
     rows: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -447,33 +476,6 @@ def _sorted_dataset_runs(
             str(run_info.get("run_hash", "")),
         ),
     )
-
-
-def resolve_latest_dataset_hashes(
-    *,
-    results_root: str = BENCHMARK_RESULTS_ROOT,
-    dataset_key: str,
-) -> tuple[str, str]:
-    root = Path(results_root)
-    history = _load_history(root / _HISTORY_FILE)
-    runs_by_hash: dict[str, Any] = history.get("runs_by_hash", {})
-    dataset_runs = _sorted_dataset_runs(
-        runs_by_hash=runs_by_hash,
-        dataset_key=dataset_key,
-    )
-
-    if len(dataset_runs) < 2:
-        available = sorted(
-            {str(run_info.get("dataset_key", "")) for run_info in runs_by_hash.values()}
-        )
-        raise ValueError(
-            "Need at least two persisted runs for dataset "
-            f"'{dataset_key}'. Available datasets in history: {', '.join(available)}"
-        )
-
-    baseline_info = dataset_runs[-2]
-    comparison_info = dataset_runs[-1]
-    return str(baseline_info["run_hash"]), str(comparison_info["run_hash"])
 
 
 def _manifest_artifact_path(
@@ -572,37 +574,50 @@ def _backfill_precision_recall_curve_artifact(
     return updated_run_info
 
 
-def _normalise_comparison_baseline_hash(
-    comparison_baseline_hash: str | None,
-) -> str | None:
-    if comparison_baseline_hash is None:
+def _find_dataset_run_by_run_id(
+    *,
+    runs_by_hash: dict[str, Any],
+    dataset_key: str,
+    run_id: str,
+) -> dict[str, Any] | None:
+    normalised_run_id = run_id.strip()
+    if not normalised_run_id:
         return None
 
-    normalised = comparison_baseline_hash.strip()
-    if not normalised:
-        return None
-    if normalised.lower() == "latest":
-        return "latest"
-    return normalised
+    for run_info in reversed(
+        _sorted_dataset_runs(
+            runs_by_hash=runs_by_hash,
+            dataset_key=dataset_key,
+        )
+    ):
+        if _run_info_run_id(run_info) == normalised_run_id:
+            return run_info
+    return None
 
 
 def _resolve_requested_baseline_info(
     *,
     runs_by_hash: dict[str, Any],
     dataset_key: str,
-    comparison_baseline_hash: str | None,
+    comparison_baseline_run_id: str | None,
+    current_run_id: str,
     current_run_hash: str,
 ) -> tuple[dict[str, Any] | None, str | None]:
-    normalised_baseline_hash = _normalise_comparison_baseline_hash(
-        comparison_baseline_hash
-    )
+    if comparison_baseline_run_id is None:
+        normalised_baseline_run_id = None
+    else:
+        normalised_baseline_run_id = comparison_baseline_run_id.strip() or None
+        if normalised_baseline_run_id is not None:
+            normalised_baseline_run_id = normalised_baseline_run_id.lower()
+            if normalised_baseline_run_id != "latest":
+                normalised_baseline_run_id = comparison_baseline_run_id.strip()
 
-    if normalised_baseline_hash == current_run_hash:
+    if normalised_baseline_run_id == current_run_id:
         raise ValueError(
-            "comparison_baseline_hash must differ from the current run hash."
+            "comparison_baseline_run_id must differ from the current run_id."
         )
 
-    if normalised_baseline_hash == "latest":
+    if normalised_baseline_run_id == "latest":
         dataset_runs = _sorted_dataset_runs(
             runs_by_hash=runs_by_hash,
             dataset_key=dataset_key,
@@ -616,21 +631,27 @@ def _resolve_requested_baseline_info(
             f"'latest' baseline on dataset '{dataset_key}'.",
         )
 
-    if normalised_baseline_hash is None:
+    if normalised_baseline_run_id is None:
         return None, None
 
-    baseline_info = runs_by_hash.get(normalised_baseline_hash)
-    if baseline_info is None:
-        return (
-            None,
-            "Comparison skipped: unknown comparison_baseline_hash "
-            f"'{normalised_baseline_hash}'.",
-        )
-    return baseline_info, None
+    baseline_info = _find_dataset_run_by_run_id(
+        runs_by_hash=runs_by_hash,
+        dataset_key=dataset_key,
+        run_id=normalised_baseline_run_id,
+    )
+    if baseline_info is not None:
+        return baseline_info, None
+
+    return (
+        None,
+        "Comparison skipped: unknown comparison_baseline_run_id "
+        f"'{normalised_baseline_run_id}' for dataset '{dataset_key}'.",
+    )
 
 
 def persist_benchmark_run(
     *,
+    run_id: str | None = None,
     dataset_key: str,
     dataset_label: str,
     stages: list[Any],
@@ -643,14 +664,16 @@ def persist_benchmark_run(
     precision: float | None,
     recall: float | None,
     precision_recall_curve_rows: list[dict[str, Any]] | None = None,
-    comparison_baseline_hash: str | None = None,
+    comparison_baseline_run_id: str | None = None,
     results_root: str = BENCHMARK_RESULTS_ROOT,
     enable_chart_exports: bool = True,
 ) -> PersistedBenchmarkRun:
     root = Path(results_root)
     history_path = root / _HISTORY_FILE
 
-    created_at = _now_utc_iso()
+    created_at_dt = datetime.now(timezone.utc)
+    created_at = created_at_dt.isoformat()
+    run_id = _normalise_run_id(run_id=run_id, fallback_at=created_at_dt)
     stage_fingerprint, stage_definition = _stage_fingerprint(stages)
     group_key = _build_group_key(
         dataset_key=dataset_key,
@@ -676,9 +699,6 @@ def persist_benchmark_run(
         stage_rows=stage_hash_rows,
         precision_recall_curve_rows=precision_recall_curve_hash_rows,
     )
-    comparison_baseline_hash = _normalise_comparison_baseline_hash(
-        comparison_baseline_hash
-    )
 
     history = _load_history(history_path)
     runs_by_hash: dict[str, Any] = history["runs_by_hash"]
@@ -695,7 +715,8 @@ def persist_benchmark_run(
         baseline_info, comparison_warning = _resolve_requested_baseline_info(
             runs_by_hash=runs_by_hash,
             dataset_key=dataset_key,
-            comparison_baseline_hash=comparison_baseline_hash,
+            comparison_baseline_run_id=comparison_baseline_run_id,
+            current_run_id=run_id,
             current_run_hash=run_hash,
         )
         if baseline_info is not None:
@@ -711,6 +732,7 @@ def persist_benchmark_run(
         history["latest_by_group"] = latest_by_group
         _atomic_write_json(history_path, history)
         return PersistedBenchmarkRun(
+            run_id=_run_info_run_id(updated_existing, fallback_hash=run_hash),
             run_hash=run_hash,
             group_key=group_key,
             created_at_utc=updated_existing.get("created_at_utc", created_at),
@@ -725,7 +747,7 @@ def persist_benchmark_run(
 
     date_bucket = created_at.split("T", 1)[0]
     dataset_segment = _safe_path_segment(dataset_key)
-    run_dir = root / dataset_segment / date_bucket / run_hash
+    run_dir = root / dataset_segment / date_bucket / run_id
     charts_dir = run_dir / "charts"
     run_dir.mkdir(parents=True, exist_ok=True)
     charts_dir.mkdir(parents=True, exist_ok=True)
@@ -754,7 +776,8 @@ def persist_benchmark_run(
     baseline_info, comparison_warning = _resolve_requested_baseline_info(
         runs_by_hash=runs_by_hash,
         dataset_key=dataset_key,
-        comparison_baseline_hash=comparison_baseline_hash,
+        comparison_baseline_run_id=comparison_baseline_run_id,
+        current_run_id=run_id,
         current_run_hash=run_hash,
     )
     if baseline_info is None and previous_dataset_runs:
@@ -766,6 +789,7 @@ def persist_benchmark_run(
             baseline_info=baseline_info,
             current_info={
                 "run_hash": run_hash,
+                "run_id": run_id,
                 "run_dir": _to_relative(run_dir),
                 "manifest_path": _to_relative(manifest_path),
                 "dataset_key": dataset_key,
@@ -787,6 +811,7 @@ def persist_benchmark_run(
         )
 
     manifest = {
+        "run_id": run_id,
         "run_hash": run_hash,
         "dataset_key": dataset_key,
         "dataset_label": dataset_label,
@@ -825,6 +850,7 @@ def persist_benchmark_run(
 
     runs_by_hash[run_hash] = {
         "run_hash": run_hash,
+        "run_id": run_id,
         "dataset_key": dataset_key,
         "dataset_label": dataset_label,
         "created_at_utc": created_at,
@@ -849,6 +875,7 @@ def persist_benchmark_run(
     _atomic_write_json(history_path, history)
 
     return PersistedBenchmarkRun(
+        run_id=run_id,
         run_hash=run_hash,
         group_key=group_key,
         created_at_utc=created_at,
@@ -874,15 +901,17 @@ def _resolve_artifact_path(path_value: str, *, results_root: Path) -> Path:
 def _comparison_artifact_paths(
     *,
     current_run_dir: Path,
-    baseline_hash: str,
-    current_hash: str,
+    baseline_run_id: str,
+    current_run_id: str,
     export_charts: bool,
 ) -> dict[str, Path]:
     charts_dir = current_run_dir / "charts"
     if export_charts:
         charts_dir.mkdir(parents=True, exist_ok=True)
 
-    file_suffix = f"{baseline_hash}_vs_{current_hash}"
+    file_suffix = (
+        f"{_safe_path_segment(baseline_run_id)}_vs_{_safe_path_segment(current_run_id)}"
+    )
     return {
         "summary_path": current_run_dir / f"comparison_summary_{file_suffix}.json",
         "markdown_report_path": (current_run_dir / f"comparison_report_{file_suffix}.md"),
@@ -920,13 +949,21 @@ def _build_overlay_chart(
         return None
 
     try:
+        baseline_run_id = _run_info_run_id(
+            baseline_info,
+            fallback_hash=str(baseline_info["run_hash"]),
+        )
+        current_run_id = _run_info_run_id(
+            current_info,
+            fallback_hash=str(current_info["run_hash"]),
+        )
         baseline_chart = build_precision_recall_chart_definition(baseline_curve_rows)
         current_chart = build_precision_recall_chart_definition(current_curve_rows)
         overlay_chart = overlay_precision_recall_charts(
             baseline_chart=baseline_chart,
             comparison_charts=current_chart,
-            baseline_label=f"Baseline {baseline_info['run_hash']}",
-            comparison_labels=f"Comparison {current_info['run_hash']}",
+            baseline_label=f"Baseline {baseline_run_id}",
+            comparison_labels=f"Comparison {current_run_id}",
         )
         chart_definition = (
             overlay_chart.to_dict()
@@ -936,16 +973,15 @@ def _build_overlay_chart(
         if not isinstance(chart_definition, dict):
             return None
         chart_definition["title"] = (
-            "Precision-Recall Curve Comparison: "
-            f"{baseline_info['run_hash']} vs {current_info['run_hash']}"
+            f"Precision-Recall Curve Comparison: {baseline_run_id} vs {current_run_id}"
         )
         _atomic_write_json(output_spec_path, chart_definition)
         write_overlay_precision_recall_chart_html(
             path=output_html_path,
             baseline_chart=baseline_chart,
             comparison_charts=current_chart,
-            baseline_label=f"Baseline {baseline_info['run_hash']}",
-            comparison_labels=f"Comparison {current_info['run_hash']}",
+            baseline_label=f"Baseline {baseline_run_id}",
+            comparison_labels=f"Comparison {current_run_id}",
             title=str(chart_definition["title"]),
         )
     except (TypeError, ValueError):
@@ -962,6 +998,14 @@ def _build_persisted_run_comparison(
 ) -> BenchmarkComparisonSummary:
     _validate_comparison_pair(baseline_info=baseline_info, current_info=current_info)
 
+    baseline_run_id = _run_info_run_id(
+        baseline_info,
+        fallback_hash=str(baseline_info["run_hash"]),
+    )
+    current_run_id = _run_info_run_id(
+        current_info,
+        fallback_hash=str(current_info["run_hash"]),
+    )
     baseline_hash = str(baseline_info["run_hash"])
     current_hash = str(current_info["run_hash"])
 
@@ -1003,14 +1047,16 @@ def _build_persisted_run_comparison(
     )
     artifact_paths = _comparison_artifact_paths(
         current_run_dir=current_run_dir,
-        baseline_hash=baseline_hash,
-        current_hash=current_hash,
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         export_charts=export_charts,
     )
 
     accuracy_comparison_rows = build_accuracy_comparison_rows(
         baseline_rows=baseline_accuracy_rows,
         current_rows=current_accuracy_rows,
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         baseline_git_commit_hash=baseline_info.get("git_commit_hash"),
@@ -1019,6 +1065,8 @@ def _build_persisted_run_comparison(
     stage_diagnostics_comparison_rows = build_stage_diagnostics_comparison_rows(
         baseline_rows=baseline_stage_rows,
         current_rows=current_stage_rows,
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         baseline_git_commit_hash=baseline_info.get("git_commit_hash"),
@@ -1039,6 +1087,8 @@ def _build_persisted_run_comparison(
             chart_paths.append(overlay_chart)
 
     return build_comparison_summary(
+        baseline_run_id=baseline_run_id,
+        current_run_id=current_run_id,
         baseline_hash=baseline_hash,
         current_hash=current_hash,
         baseline_accuracy_rows=baseline_accuracy_rows,
@@ -1067,14 +1117,15 @@ def _build_persisted_run_comparison(
 def compare_persisted_runs(
     *,
     results_root: str = BENCHMARK_RESULTS_ROOT,
-    comparison_hash: str,
-    baseline_hash: str,
+    dataset_key: str,
+    comparison_run_id: str,
+    baseline_run_id: str,
     export_charts: bool = True,
 ) -> PersistedBenchmarkRun:
-    """Compare two explicit persisted runs by hash.
+    """Compare two explicit persisted runs by dataset-scoped run_id.
 
-    ``baseline_hash`` provides baseline values, and ``comparison_hash`` is compared
-    against it.
+    ``baseline_run_id`` provides baseline values, and ``comparison_run_id`` is
+    compared against it.
     """
     root = Path(results_root)
     history_path = root / _HISTORY_FILE
@@ -1084,19 +1135,28 @@ def compare_persisted_runs(
     if not runs_by_hash:
         raise ValueError(f"No persisted benchmark runs found under '{results_root}'.")
 
-    if comparison_hash not in runs_by_hash:
+    current_info = _find_dataset_run_by_run_id(
+        runs_by_hash=runs_by_hash,
+        dataset_key=dataset_key,
+        run_id=comparison_run_id,
+    )
+    if current_info is None:
         raise ValueError(
-            f"Unknown comparison_hash '{comparison_hash}'. "
-            f"Check {_history_hint(root)} for available hashes."
-        )
-    if baseline_hash not in runs_by_hash:
-        raise ValueError(
-            f"Unknown baseline_hash '{baseline_hash}'. "
-            f"Check {_history_hint(root)} for available hashes."
+            f"Unknown comparison_run_id '{comparison_run_id}' for dataset "
+            f"'{dataset_key}'. Check {_history_hint(root)} for available run_ids."
         )
 
-    current_info = runs_by_hash[comparison_hash]
-    baseline_info = runs_by_hash[baseline_hash]
+    baseline_info = _find_dataset_run_by_run_id(
+        runs_by_hash=runs_by_hash,
+        dataset_key=dataset_key,
+        run_id=baseline_run_id,
+    )
+    if baseline_info is None:
+        raise ValueError(
+            f"Unknown baseline_run_id '{baseline_run_id}' for dataset "
+            f"'{dataset_key}'. Check {_history_hint(root)} for available run_ids."
+        )
+
     comparison = _build_persisted_run_comparison(
         results_root=root,
         baseline_info=baseline_info,
@@ -1105,7 +1165,11 @@ def compare_persisted_runs(
     )
 
     return PersistedBenchmarkRun(
-        run_hash=comparison_hash,
+        run_id=_run_info_run_id(
+            current_info,
+            fallback_hash=str(current_info.get("run_hash", "")),
+        ),
+        run_hash=str(current_info.get("run_hash", "")),
         group_key=str(current_info.get("group_key", "")),
         created_at_utc=str(current_info.get("created_at_utc", "")),
         run_dir=str(current_info.get("run_dir", "")),

--- a/benchmarking/insights/types.py
+++ b/benchmarking/insights/types.py
@@ -41,6 +41,8 @@ class BenchmarkOutputOptions:
 
 @dataclass(frozen=True)
 class BenchmarkComparisonSummary:
+    baseline_run_id: str
+    current_run_id: str
     baseline_hash: str
     current_hash: str
     overall_delta: dict[str, float | None]
@@ -55,6 +57,7 @@ class BenchmarkComparisonSummary:
 
 @dataclass(frozen=True)
 class PersistedBenchmarkRun:
+    run_id: str
     run_hash: str
     group_key: str
     created_at_utc: str

--- a/benchmarking/run_benchmarking.py
+++ b/benchmarking/run_benchmarking.py
@@ -12,7 +12,6 @@ from benchmarking.constants import (
 )
 from benchmarking.insights.reporting import (
     print_benchmark_summary,
-    print_run_persistence_summary,
 )
 from benchmarking.insights.types import BenchmarkOutputOptions
 from benchmarking.runner import print_available_datasets, run_selected_datasets
@@ -38,8 +37,8 @@ STAGES = [
 ]
 # Set to a persisted run hash to force a specific baseline, or use "latest"
 # to compare against the latest other persisted run for the same dataset.
-# Set to None to disable persisting results locally.
-COMPARISON_BASELINE_HASH: str | None = "latest"
+# Run IDs are preferred; internal dedupe hashes are still accepted for older runs.
+COMPARISON_BASELINE_RUN_ID: str | None = "latest"
 
 
 # Defaults: print benchmark summaries and persistence output.
@@ -68,7 +67,7 @@ results = run_selected_datasets(
     persist_results=True,
     results_root=BENCHMARK_RESULTS_ROOT,
     enable_comparison_charts=True,
-    comparison_baseline_hash=COMPARISON_BASELINE_HASH,
+    comparison_baseline_run_id=COMPARISON_BASELINE_RUN_ID,
 )
 print_benchmark_summary(
     results,
@@ -77,4 +76,3 @@ print_benchmark_summary(
     top_k_precision_at_metrics=TOP_K_PRECISION_AT_METRICS,
     output_options=OUTPUT_OPTIONS,
 )
-print_run_persistence_summary(results)

--- a/benchmarking/runner.py
+++ b/benchmarking/runner.py
@@ -11,7 +11,11 @@ from benchmarking.config.datasets import (
 )
 from benchmarking.constants import BENCHMARK_RESULTS_ROOT
 from benchmarking.insights.diagnostics import build_dataset_diagnostics
-from benchmarking.insights.run_persistence import persist_benchmark_run
+from benchmarking.insights.reporting import print_run_persistence_summary
+from benchmarking.insights.run_persistence import (
+    generate_benchmark_run_id,
+    persist_benchmark_run,
+)
 from benchmarking.insights.summary import fetch_overall_summary
 from benchmarking.insights.types import DatasetDiagnostics, PersistedBenchmarkRun
 from benchmarking.utils.io import setup_connection
@@ -71,6 +75,7 @@ def run_single_dataset(
     dataset_key: str,
     canonical_path: str,
     stages: list,
+    run_id: str | None = None,
     sample_mode: bool = False,
     canonical_address_filter: str | None = None,
     enable_diagnostics: bool = False,
@@ -78,7 +83,7 @@ def run_single_dataset(
     persist_results: bool = False,
     results_root: str = BENCHMARK_RESULTS_ROOT,
     enable_comparison_charts: bool = True,
-    comparison_baseline_hash: str | None = None,
+    comparison_baseline_run_id: str | None = None,
 ) -> BenchmarkRunResult:
     dataset = get_dataset_definition(dataset_key)
     timings: dict[str, float] = {}
@@ -137,6 +142,7 @@ def run_single_dataset(
     persisted_run: PersistedBenchmarkRun | None = None
     if persist_results:
         persisted_run = persist_benchmark_run(
+            run_id=run_id,
             dataset_key=dataset_key,
             dataset_label=dataset["label"],
             stages=stages,
@@ -149,7 +155,7 @@ def run_single_dataset(
             precision=precision,
             recall=recall,
             precision_recall_curve_rows=precision_recall_curve_records,
-            comparison_baseline_hash=comparison_baseline_hash,
+            comparison_baseline_run_id=comparison_baseline_run_id,
             results_root=results_root,
             enable_chart_exports=enable_comparison_charts,
         )
@@ -179,6 +185,7 @@ def run_selected_datasets(
     selected_datasets: str | list[str],
     canonical_path: str,
     stages: list,
+    run_id: str | None = None,
     sample_mode: bool = False,
     canonical_address_filter: str | None = None,
     enable_diagnostics: bool = False,
@@ -186,19 +193,23 @@ def run_selected_datasets(
     persist_results: bool = False,
     results_root: str = BENCHMARK_RESULTS_ROOT,
     enable_comparison_charts: bool = True,
-    comparison_baseline_hash: str | None = None,
+    comparison_baseline_run_id: str | None = None,
 ) -> list[BenchmarkRunResult]:
     selected = resolve_dataset_selection(selected_datasets)
-    con = setup_connection()
+    effective_run_id = run_id.strip() if isinstance(run_id, str) else run_id
+    if not effective_run_id:
+        effective_run_id = generate_benchmark_run_id()
 
     results: list[BenchmarkRunResult] = []
     for dataset_key in selected:
+        con = setup_connection()
         print(f"\nRunning benchmark for dataset: {dataset_key}")
         result = run_single_dataset(
             con=con,
             dataset_key=dataset_key,
             canonical_path=canonical_path,
             stages=stages,
+            run_id=effective_run_id,
             sample_mode=sample_mode,
             canonical_address_filter=canonical_address_filter,
             enable_diagnostics=enable_diagnostics,
@@ -206,11 +217,14 @@ def run_selected_datasets(
             persist_results=persist_results,
             results_root=results_root,
             enable_comparison_charts=enable_comparison_charts,
-            comparison_baseline_hash=comparison_baseline_hash,
+            comparison_baseline_run_id=comparison_baseline_run_id,
         )
         print(
             f"Completed dataset '{dataset_key}' in {result.timings['total_runtime']:.2f}s"
         )
         results.append(result)
+
+    if persist_results:
+        print_run_persistence_summary(results)
 
     return results

--- a/tests/test_run_persistence.py
+++ b/tests/test_run_persistence.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import duckdb
+
+from benchmarking.insights.run_persistence import (
+    compare_persisted_runs,
+    generate_benchmark_run_id,
+    persist_benchmark_run,
+)
+from benchmarking.runner import BenchmarkRunResult, run_selected_datasets
+
+
+@dataclass(frozen=True)
+class DummyStage:
+    final_match_weight_threshold: float = 0.5
+
+
+def _accuracy_table_relation(con: duckdb.DuckDBPyConnection) -> duckdb.DuckDBPyRelation:
+    return con.sql(
+        """
+        SELECT *
+        FROM (
+            VALUES
+                ('overall', 10, 8, 7, 1, 3, 0.875, 0.7)
+        ) AS t(
+            match_reason,
+            total_rows,
+            matched_rows,
+            correct_matches,
+            wrong_matches,
+            unmatched_rows,
+            precision,
+            recall
+        )
+        """
+    )
+
+
+def _stage_diagnostics_relation(
+    con: duckdb.DuckDBPyConnection,
+) -> duckdb.DuckDBPyRelation:
+    return con.sql(
+        """
+        SELECT *
+        FROM (
+            VALUES
+                ('exact_match', 0.123, 10, 8)
+        ) AS t(stage, elapsed_seconds, input_rows, output_rows)
+        """
+    )
+
+
+def test_generate_benchmark_run_id_hashes_timestamp_seed() -> None:
+    timestamp = datetime(2026, 4, 9, 18, 34, 9, 950154, tzinfo=timezone.utc)
+    timestamp_seed = "20260409T183409950154Z"
+
+    assert (
+        generate_benchmark_run_id(at=timestamp)
+        == hashlib.sha256(timestamp_seed.encode("utf-8")).hexdigest()[:16]
+    )
+    assert generate_benchmark_run_id(at=timestamp) != timestamp_seed
+
+
+def test_persist_benchmark_run_records_run_id_and_legacy_hash(tmp_path: Path) -> None:
+    con = duckdb.connect(database=":memory:")
+    run_id = "c7337f8f317d3734"
+
+    persisted = persist_benchmark_run(
+        run_id=run_id,
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=_accuracy_table_relation(con),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.234},
+        total_rows=10,
+        matched_rows=8,
+        correct_matches=7,
+        precision=0.875,
+        recall=0.7,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+
+    manifest = json.loads(Path(persisted.manifest_path).read_text(encoding="utf-8"))
+    history = json.loads((tmp_path / "run_history.json").read_text(encoding="utf-8"))
+
+    assert persisted.run_id == run_id
+    assert persisted.run_hash == manifest["run_hash"]
+    assert manifest["run_id"] == run_id
+    assert history["runs_by_hash"][persisted.run_hash]["run_id"] == run_id
+    assert persisted.run_hash != run_id
+    assert run_id in persisted.manifest_path
+    assert persisted.deduplicated is False
+
+
+def test_persist_benchmark_run_deduplicates_by_legacy_hash(tmp_path: Path) -> None:
+    con = duckdb.connect(database=":memory:")
+
+    first = persist_benchmark_run(
+        run_id="c7337f8f317d3734",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=_accuracy_table_relation(con),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.234},
+        total_rows=10,
+        matched_rows=8,
+        correct_matches=7,
+        precision=0.875,
+        recall=0.7,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+    second = persist_benchmark_run(
+        run_id="3f763df1ae74435a",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=_accuracy_table_relation(con),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 9.999},
+        total_rows=10,
+        matched_rows=8,
+        correct_matches=7,
+        precision=0.875,
+        recall=0.7,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+
+    history = json.loads((tmp_path / "run_history.json").read_text(encoding="utf-8"))
+
+    assert second.deduplicated is True
+    assert second.run_hash == first.run_hash
+    assert second.manifest_path == first.manifest_path
+    assert second.run_id == first.run_id
+    assert list(history["runs_by_hash"]) == [first.run_hash]
+
+
+def test_persist_benchmark_run_compares_against_baseline_run_id(tmp_path: Path) -> None:
+    con = duckdb.connect(database=":memory:")
+
+    baseline = persist_benchmark_run(
+        run_id="c7337f8f317d3734",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=con.sql(
+            """
+            SELECT *
+            FROM (
+                VALUES
+                    ('overall', 10, 8, 7, 1, 3, 0.875, 0.7)
+            ) AS t(
+                match_reason,
+                total_rows,
+                matched_rows,
+                correct_matches,
+                wrong_matches,
+                unmatched_rows,
+                precision,
+                recall
+            )
+            """
+        ),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.234},
+        total_rows=10,
+        matched_rows=8,
+        correct_matches=7,
+        precision=0.875,
+        recall=0.7,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+
+    comparison = persist_benchmark_run(
+        run_id="3f763df1ae74435a",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=con.sql(
+            """
+            SELECT *
+            FROM (
+                VALUES
+                    ('overall', 10, 9, 8, 1, 2, 0.8889, 0.8)
+            ) AS t(
+                match_reason,
+                total_rows,
+                matched_rows,
+                correct_matches,
+                wrong_matches,
+                unmatched_rows,
+                precision,
+                recall
+            )
+            """
+        ),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.111},
+        total_rows=10,
+        matched_rows=9,
+        correct_matches=8,
+        precision=0.8889,
+        recall=0.8,
+        comparison_baseline_run_id=baseline.run_id,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+
+    assert comparison.comparison is not None
+    assert comparison.comparison.baseline_run_id == baseline.run_id
+    assert comparison.comparison.current_run_id == comparison.run_id
+    assert baseline.run_id in comparison.comparison.summary_path
+    assert comparison.run_id in comparison.comparison.summary_path
+
+
+def test_compare_persisted_runs_accepts_run_ids(tmp_path: Path) -> None:
+    con = duckdb.connect(database=":memory:")
+
+    baseline = persist_benchmark_run(
+        run_id="c7337f8f317d3734",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=con.sql(
+            """
+            SELECT *
+            FROM (
+                VALUES
+                    ('overall', 10, 8, 7, 1, 3, 0.875, 0.7)
+            ) AS t(
+                match_reason,
+                total_rows,
+                matched_rows,
+                correct_matches,
+                wrong_matches,
+                unmatched_rows,
+                precision,
+                recall
+            )
+            """
+        ),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.234},
+        total_rows=10,
+        matched_rows=8,
+        correct_matches=7,
+        precision=0.875,
+        recall=0.7,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+    current = persist_benchmark_run(
+        run_id="3f763df1ae74435a",
+        dataset_key="hackney",
+        dataset_label="Hackney",
+        stages=[DummyStage()],
+        accuracy_table=con.sql(
+            """
+            SELECT *
+            FROM (
+                VALUES
+                    ('overall', 10, 9, 8, 1, 2, 0.8889, 0.8)
+            ) AS t(
+                match_reason,
+                total_rows,
+                matched_rows,
+                correct_matches,
+                wrong_matches,
+                unmatched_rows,
+                precision,
+                recall
+            )
+            """
+        ),
+        stage_diagnostics_table=_stage_diagnostics_relation(con),
+        timings={"total_runtime": 1.111},
+        total_rows=10,
+        matched_rows=9,
+        correct_matches=8,
+        precision=0.8889,
+        recall=0.8,
+        results_root=str(tmp_path),
+        enable_chart_exports=False,
+    )
+
+    comparison_run = compare_persisted_runs(
+        results_root=str(tmp_path),
+        dataset_key="hackney",
+        baseline_run_id=baseline.run_id,
+        comparison_run_id=current.run_id,
+        export_charts=False,
+    )
+
+    assert comparison_run.comparison is not None
+    assert comparison_run.comparison.baseline_run_id == baseline.run_id
+    assert comparison_run.comparison.current_run_id == current.run_id
+
+
+def test_run_selected_datasets_passes_shared_run_id(monkeypatch) -> None:
+    captured_run_ids: list[str | None] = []
+    shared_run_id = "c7337f8f317d3734"
+
+    def fake_run_single_dataset(**kwargs):
+        captured_run_ids.append(kwargs["run_id"])
+        return BenchmarkRunResult(
+            dataset_key=kwargs["dataset_key"],
+            dataset_label=kwargs["dataset_key"].title(),
+            total_rows=1,
+            matched_rows=1,
+            correct_matches=1,
+            precision=1.0,
+            recall=1.0,
+            match_reason_breakdown=object(),
+            timings={"total_runtime": 0.01},
+            con=object(),
+        )
+
+    monkeypatch.setattr(
+        "benchmarking.runner.resolve_dataset_selection",
+        lambda selection: ["hackney", "lambeth_llpg"],
+    )
+    monkeypatch.setattr("benchmarking.runner.setup_connection", lambda: object())
+    monkeypatch.setattr("benchmarking.runner.run_single_dataset", fake_run_single_dataset)
+
+    results = run_selected_datasets(
+        selected_datasets=["hackney", "lambeth_llpg"],
+        canonical_path="canonical.parquet",
+        stages=[DummyStage()],
+        run_id=shared_run_id,
+    )
+
+    assert [result.dataset_key for result in results] == ["hackney", "lambeth_llpg"]
+    assert captured_run_ids == [shared_run_id, shared_run_id]
+
+
+def test_run_selected_datasets_generates_shared_run_id_once(monkeypatch) -> None:
+    captured_run_ids: list[str | None] = []
+    generated_run_ids: list[str] = []
+    shared_run_id = "3f763df1ae74435a"
+
+    def fake_generate_benchmark_run_id() -> str:
+        generated_run_ids.append(shared_run_id)
+        return shared_run_id
+
+    def fake_run_single_dataset(**kwargs):
+        captured_run_ids.append(kwargs["run_id"])
+        return BenchmarkRunResult(
+            dataset_key=kwargs["dataset_key"],
+            dataset_label=kwargs["dataset_key"].title(),
+            total_rows=1,
+            matched_rows=1,
+            correct_matches=1,
+            precision=1.0,
+            recall=1.0,
+            match_reason_breakdown=object(),
+            timings={"total_runtime": 0.01},
+            con=object(),
+        )
+
+    monkeypatch.setattr(
+        "benchmarking.runner.resolve_dataset_selection",
+        lambda selection: ["hackney", "lambeth_llpg"],
+    )
+    monkeypatch.setattr("benchmarking.runner.setup_connection", lambda: object())
+    monkeypatch.setattr(
+        "benchmarking.runner.generate_benchmark_run_id",
+        fake_generate_benchmark_run_id,
+    )
+    monkeypatch.setattr("benchmarking.runner.run_single_dataset", fake_run_single_dataset)
+
+    results = run_selected_datasets(
+        selected_datasets=["hackney", "lambeth_llpg"],
+        canonical_path="canonical.parquet",
+        stages=[DummyStage()],
+    )
+
+    assert [result.dataset_key for result in results] == ["hackney", "lambeth_llpg"]
+    assert generated_run_ids == [shared_run_id]
+    assert captured_run_ids == [shared_run_id, shared_run_id]
+
+
+def test_run_selected_datasets_prints_persistence_summary_when_enabled(
+    monkeypatch,
+) -> None:
+    captured_results: list[list[BenchmarkRunResult]] = []
+
+    def fake_run_single_dataset(**kwargs):
+        return BenchmarkRunResult(
+            dataset_key=kwargs["dataset_key"],
+            dataset_label=kwargs["dataset_key"].title(),
+            total_rows=1,
+            matched_rows=1,
+            correct_matches=1,
+            precision=1.0,
+            recall=1.0,
+            match_reason_breakdown=object(),
+            timings={"total_runtime": 0.01},
+            con=object(),
+            persisted_run=object(),
+        )
+
+    def fake_print_run_persistence_summary(results: list[BenchmarkRunResult]) -> None:
+        captured_results.append(results)
+
+    monkeypatch.setattr(
+        "benchmarking.runner.resolve_dataset_selection",
+        lambda selection: ["hackney", "lambeth_llpg"],
+    )
+    monkeypatch.setattr("benchmarking.runner.setup_connection", lambda: object())
+    monkeypatch.setattr("benchmarking.runner.run_single_dataset", fake_run_single_dataset)
+    monkeypatch.setattr(
+        "benchmarking.runner.print_run_persistence_summary",
+        fake_print_run_persistence_summary,
+    )
+
+    results = run_selected_datasets(
+        selected_datasets=["hackney", "lambeth_llpg"],
+        canonical_path="canonical.parquet",
+        stages=[DummyStage()],
+        persist_results=True,
+    )
+
+    assert [result.dataset_key for result in results] == ["hackney", "lambeth_llpg"]
+    assert captured_results == [results]

--- a/uk_address_matcher/analysis/accuracy_table.py
+++ b/uk_address_matcher/analysis/accuracy_table.py
@@ -64,7 +64,7 @@ def build_accuracy_table(
     splink_reason_sql = f"'{splink_value}'::ENUM {enum_values}"
     precision_sql = ratio_sql(
         "correct_matches",
-        "matched_row_count",
+        "rows_matched_in_stage",
         when_zero_sql="NULL::DOUBLE",
     )
     recall_sql = ratio_sql(
@@ -74,11 +74,11 @@ def build_accuracy_table(
     )
     f1_sql = f1_from_counts_sql(
         tp_sql="correct_matches",
-        fp_sql="(matched_row_count - correct_matches)",
+        fp_sql="(rows_matched_in_stage - correct_matches)",
         fn_sql="((SELECT total_input_rows FROM totals) - correct_matches)",
     )
     wrong_match_rate_expr = wrong_match_rate_sql(
-        rows_matched_sql="matched_row_count",
+        rows_matched_sql="rows_matched_in_stage",
         correct_matches_sql="correct_matches",
     )
     correct_share_expr = correct_share_of_total_sql(
@@ -92,8 +92,6 @@ def build_accuracy_table(
             SELECT
                 CASE
                     WHEN m.match_reason IS NULL THEN 'unmatched'
-                    WHEN m.match_reason = {splink_reason_sql}
-                        AND NOT ({splink_accepted_sql}) THEN 'unmatched'
                     WHEN split_part(m.match_reason::VARCHAR, ':', 1) = 'exact'
                         THEN 'exact_matches'
                     ELSE split_part(m.match_reason::VARCHAR, ':', 1)
@@ -121,40 +119,37 @@ def build_accuracy_table(
                     WHEN GROUPING(stage) = 1 THEN 'overall'
                     ELSE stage
                 END AS stage,
-                COUNT(*) AS stage_row_count,
-                SUM(CASE WHEN is_matched THEN 1 ELSE 0 END) AS matched_row_count,
+                COUNT(*) AS total_rows_in_stage,
+                SUM(CASE WHEN is_matched THEN 1 ELSE 0 END) AS matched_rows_in_stage,
                 SUM(CASE WHEN is_correct THEN 1 ELSE 0 END) AS correct_matches
             FROM scored
             GROUP BY GROUPING SETS ((stage), ())
-        ),
-        display_rows AS (
-            SELECT
-                stage,
-                CASE
-                    WHEN stage = 'unmatched' THEN stage_row_count
-                    ELSE matched_row_count
-                END AS rows_matched_in_stage,
-                matched_row_count,
-                correct_matches,
-                CASE
-                    WHEN stage = 'unmatched' THEN 0
-                    ELSE matched_row_count - correct_matches
-                END AS wrong_matches
-            FROM all_rows
         )
         SELECT
             stage,
-            rows_matched_in_stage,
+            CASE
+                WHEN stage = 'unmatched' THEN total_rows_in_stage
+                ELSE matched_rows_in_stage
+            END AS rows_matched_in_stage,
             correct_matches,
-            wrong_matches,
-            ROUND(
-                {precision_sql},
-                6
-            ) AS precision,
-            ROUND(
-                {wrong_match_rate_expr},
-                2
-            ) AS wrong_match_rate,
+            CASE
+                WHEN stage = 'unmatched' THEN 0
+                ELSE matched_rows_in_stage - correct_matches
+            END AS wrong_matches,
+            CASE
+                WHEN stage = 'unmatched' THEN NULL
+                ELSE ROUND(
+                    {precision_sql},
+                    6
+                )
+            END AS precision,
+            CASE
+                WHEN stage = 'unmatched' THEN NULL
+                ELSE ROUND(
+                    {wrong_match_rate_expr},
+                    2
+                )
+            END AS wrong_match_rate,
             ROUND(
                 {correct_share_expr},
                 2
@@ -167,9 +162,12 @@ def build_accuracy_table(
                 {f1_sql},
                 6
             ) AS f1
-        FROM display_rows
+        FROM all_rows
         ORDER BY
-            rows_matched_in_stage DESC,
+            CASE
+                WHEN stage = 'unmatched' THEN total_rows_in_stage
+                ELSE matched_rows_in_stage
+            END DESC,
             stage
         """
     )


### PR DESCRIPTION
Tweaks run persistence ID values. We now generate two values whenever we perform a benchmarking run:
- `run_id`: the (hashed) unique ID value, based on the execution time of the script
- `dedupe_id`: a (hashed) unique ID based on the results of the accuracy table. This ensures we don't persist duplicated results to disk

This should make the process of comparing multiple datasets much simpler in practice. We generate some results for let's say, Lambeth and Hackney council tax datasets, generating a single run ID. We then make some adjustments to our underlying code and re-run the process, passing in the generated run_id hash key as an argument to the `run_benchmarking` script: `COMPARISON_BASELINE_RUN_ID: str | None = "<hash_key>"`

This will then compare both runs against each dataset separately and generate our desired reports.