### PR TITLE
feat(stage): include no whitespace matching logic

### DIFF
--- a/tests/test_exact_matching.py
+++ b/tests/test_exact_matching.py
@@ -6,6 +6,7 @@ from uk_address_matcher import (
 )
 from uk_address_matcher.linking_model.matching import runner as matching_runner
 from uk_address_matcher.linking_model.matching.runner import _run_matching
+from uk_address_matcher.sql_pipeline.match_reasons import MatchReason
 
 
 @pytest.fixture
@@ -124,6 +125,82 @@ def test_data(duck_con):
     )
 
     return df_fuzzy, df_canonical
+
+
+def test_exact_matching_applies_no_whitespace_fallback_by_default(duck_con):
+    df_messy = duck_con.sql(
+        """
+        SELECT *
+        FROM (
+            VALUES
+                (
+                    1,
+                    '12 HIGH ROAD',
+                    '12 HIGH ROAD',
+                    'AA1 1AA',
+                    CAST([] AS VARCHAR[]),
+                    1::BIGINT
+                )
+        ) AS t(
+            unique_id,
+            original_address_concat,
+            clean_full_address,
+            postcode,
+            peeled_tokens_list,
+            ukam_address_id
+        )
+        """
+    )
+
+    df_canonical = duck_con.sql(
+        """
+        SELECT *
+        FROM (
+            VALUES
+                (
+                    1001,
+                    '12HIGHROAD',
+                    '12HIGHROAD',
+                    'AA1 1AA',
+                    CAST([] AS VARCHAR[]),
+                    ARRAY['12']::VARCHAR[],
+                    FALSE,
+                    NULL::VARCHAR,
+                    NULL::VARCHAR,
+                    NULL::VARCHAR,
+                    FALSE,
+                    NULL::VARCHAR,
+                    NULL::VARCHAR,
+                    10::BIGINT
+                )
+        ) AS t(
+            unique_id,
+            original_address_concat,
+            clean_full_address,
+            postcode,
+            peeled_tokens_list,
+            numeric_tokens,
+            has_flat_indicator,
+            flat_positional,
+            flat_letter,
+            flat_number,
+            has_business_unit,
+            business_unit_type,
+            business_unit_id,
+            ukam_address_id
+        )
+        """
+    )
+
+    results, _ = _run_matching(
+        con=duck_con,
+        df_messy_clean=df_messy,
+        df_canonical_clean=df_canonical,
+        stages=[ExactMatchStage()],
+    )
+    row = results.fetchdf().iloc[0]
+    assert row["resolved_canonical_id"] == 1001
+    assert row["match_reason"] == MatchReason.EXACT_NO_WHITESPACE.value
 
 
 # -----------------------------------------------------------------------------

--- a/uk_address_matcher/linking_model/matching/stages/exact_match.py
+++ b/uk_address_matcher/linking_model/matching/stages/exact_match.py
@@ -71,7 +71,11 @@ class ExactMatchStage(MatchingStage):
 def _exact_matches(
     messy_input_name: MessyInputName = "__ukam__tmp_messy_addresses",
 ) -> list[CTEStep]:
-    """Find exact matches using hash-join on clean_full_address + postcode.
+    """Find exact and no-whitespace postcode-bounded matches.
+
+    Uses set-based equality joins and then selects one deterministic best
+    candidate per messy record, preferring exact matches over no-whitespace
+    matches.
 
     Parameters
     ----------
@@ -80,30 +84,99 @@ def _exact_matches(
         "__ukam__tmp_messy_addresses" for the initial pass. Can be set
         to "unmatched_records" when running after filtering.
     """
-    match_condition = """
+    exact_match_condition = """
         messy.clean_full_address = canon.clean_full_address
         AND messy.postcode = canon.postcode
     """
 
     exact_value = MatchReason.EXACT.value
+    exact_no_whitespace_value = MatchReason.EXACT_NO_WHITESPACE.value
     enum_values = str(MatchReason.enum_values())
-    matches_sql = f"""
+    no_ws_expression = "regexp_replace(clean_full_address, '\\s+', '', 'g')"
+
+    messy_match_keys_sql = f"""
+        SELECT
+            messy.ukam_address_id,
+            messy.postcode,
+            messy.clean_full_address,
+            {no_ws_expression} AS clean_full_address_no_ws
+        FROM {{{messy_input_name}}} AS messy
+    """
+
+    canonical_match_keys_sql = f"""
+        SELECT
+            canon.ukam_address_id AS canonical_ukam_address_id,
+            canon.canonical_unique_id,
+            canon.postcode,
+            canon.clean_full_address,
+            {no_ws_expression} AS clean_full_address_no_ws
+        FROM {{canonical_addresses_restricted}} AS canon
+    """
+
+    exact_candidates_sql = f"""
         SELECT
             messy.ukam_address_id AS ukam_address_id,
-            matched_canon.ukam_address_id AS canonical_ukam_address_id,
-            matched_canon.canonical_unique_id AS resolved_canonical_id,
-            '{exact_value}'::ENUM {enum_values} as match_reason
-        FROM {{{messy_input_name}}} AS messy
-        INNER JOIN LATERAL (
-            SELECT
-                canon.ukam_address_id as ukam_address_id,
-                canon.canonical_unique_id as canonical_unique_id
-            FROM {{canonical_addresses_restricted}} AS canon
-            WHERE {match_condition}
-            LIMIT 1
-        ) AS matched_canon ON true
+            canon.canonical_ukam_address_id,
+            canon.canonical_unique_id AS resolved_canonical_id,
+            '{exact_value}'::ENUM {enum_values} AS match_reason,
+            1 AS match_priority
+        FROM {{messy_match_keys}} AS messy
+        INNER JOIN {{canonical_match_keys}} AS canon
+            ON {exact_match_condition}
+    """
+
+    no_ws_candidates_sql = f"""
+        SELECT
+            messy.ukam_address_id AS ukam_address_id,
+            canon.canonical_ukam_address_id,
+            canon.canonical_unique_id AS resolved_canonical_id,
+            '{exact_no_whitespace_value}'::ENUM {enum_values} AS match_reason,
+            2 AS match_priority
+        FROM {{messy_match_keys}} AS messy
+        INNER JOIN {{canonical_match_keys}} AS canon
+            ON messy.postcode = canon.postcode
+            AND messy.clean_full_address_no_ws = canon.clean_full_address_no_ws
+            AND messy.clean_full_address_no_ws <> ''
+            AND messy.clean_full_address <> canon.clean_full_address
+    """
+
+    all_exact_candidates_sql = """
+        SELECT * FROM {exact_candidates}
+        UNION ALL
+        SELECT * FROM {no_ws_candidates}
+    """
+
+    ranked_exact_candidates_sql = """
+        SELECT
+            candidates.ukam_address_id,
+            candidates.canonical_ukam_address_id,
+            candidates.resolved_canonical_id,
+            candidates.match_reason,
+            ROW_NUMBER() OVER (
+                PARTITION BY candidates.ukam_address_id
+                ORDER BY
+                    candidates.match_priority,
+                    candidates.canonical_ukam_address_id
+            ) AS rn
+        FROM {all_exact_candidates} AS candidates
+    """
+
+    exact_matches_sql = """
+        SELECT
+            ukam_address_id,
+            canonical_ukam_address_id,
+            resolved_canonical_id,
+            match_reason
+        FROM {ranked_exact_candidates}
+        WHERE rn = 1
     """
 
     return [
-        CTEStep("exact_matches", matches_sql),
+        CTEStep("messy_match_keys", messy_match_keys_sql),
+        CTEStep("canonical_match_keys", canonical_match_keys_sql),
+        CTEStep("exact_candidates", exact_candidates_sql),
+        CTEStep("no_ws_candidates", no_ws_candidates_sql),
+        CTEStep("all_exact_candidates", all_exact_candidates_sql),
+        CTEStep("ranked_exact_candidates", ranked_exact_candidates_sql),
+        CTEStep("exact_matches", exact_matches_sql),
     ]

--- a/uk_address_matcher/sql_pipeline/match_reasons.py
+++ b/uk_address_matcher/sql_pipeline/match_reasons.py
@@ -7,6 +7,7 @@ class MatchReason(Enum):
     """Canonical set of match reason values shared between Python and DuckDB."""
 
     EXACT = "exact: full match"
+    EXACT_NO_WHITESPACE = "exact_no_whitespace: full match after removing whitespace"
     PEELED_ADDRESS = "peeled_address: match after removing common UK end tokens"
     SPLINK = "splink: probabilistic match"
     UNIQUE_TRIGRAM = "unique_trigram: unique trigram match"
@@ -19,6 +20,8 @@ class MatchReason(Enum):
         """Simplified stage name used in reporting tables."""
         if self is MatchReason.EXACT:
             return "exact_matches"
+        if self is MatchReason.EXACT_NO_WHITESPACE:
+            return "exact_no_whitespace"
         if self is MatchReason.PEELED_ADDRESS:
             return "peeled_address"
         if self is MatchReason.SPLINK:


### PR DESCRIPTION
A fairly simple addition to the exact matcher that checks for exact matches without whitespace. This allows us to search for comparisons where whitespace/variant spellings were used for address strings.

For example:
`MID LOATHIAN` vs `MIDLOTHIAN`.

Results for Aberdeenshire - no real impact on matching speed (exact matching still hovers around ~0.7 seconds on my machine):
<img width="952" height="736" alt="Screenshot 2026-04-16 at 12 39 34" src="https://github.com/user-attachments/assets/f890385b-a9bb-457f-b6d7-7a63adfeba42" />

I've tested this for other locations - all have a positive impact, but Aberdeenshire has the most new cases being found, so it's the best demo location.

```
| Metric | Baseline | Current | Delta |
| --- | --- | --- | --- |
| Correct matches | 115,504 | 116,060 | +556 |
| Precision | 98.5058% | 98.5397% | +0.0339 pp |
| Recall | 93.9294% | 94.3815% | +0.4521 pp |
| F1 | 96.1632% | 96.4158% | +0.2526 pp |
```