### PR TITLE
Feature/add flat retraction logic

### DIFF
--- a/tests/test_exact_matching.py
+++ b/tests/test_exact_matching.py
@@ -127,53 +127,7 @@ def test_data(duck_con):
     return df_fuzzy, df_canonical
 
 
-def test_exact_matching_applies_no_whitespace_fallback_by_default(duck_con):
-    df_messy = duck_con.sql(
-        """
-        SELECT *
-        FROM (
-            VALUES
-                (
-                    1,
-                    '12 HIGH ROAD',
-                    '12 HIGH ROAD',
-                    'AA1 1AA',
-                    CAST([] AS VARCHAR[]),
-                    1::BIGINT
-                )
-        ) AS t(
-            unique_id,
-            original_address_concat,
-            clean_full_address,
-            postcode,
-            peeled_tokens_list,
-            ukam_address_id
-        )
-        """
-    )
-
-    df_canonical = duck_con.sql(
-        """
-        SELECT *
-        FROM (
-            VALUES
-                (
-                    1001,
-                    '12HIGHROAD',
-                    '12HIGHROAD',
-                    'AA1 1AA',
-                    CAST([] AS VARCHAR[]),
-                    ARRAY['12']::VARCHAR[],
-                    FALSE,
-                    NULL::VARCHAR,
-                    NULL::VARCHAR,
-                    NULL::VARCHAR,
-                    FALSE,
-                    NULL::VARCHAR,
-                    NULL::VARCHAR,
-                    10::BIGINT
-                )
-        ) AS t(
+ADDRESS_ROW_COLUMNS_SQL = """
             unique_id,
             original_address_concat,
             clean_full_address,
@@ -188,9 +142,121 @@ def test_exact_matching_applies_no_whitespace_fallback_by_default(duck_con):
             business_unit_type,
             business_unit_id,
             ukam_address_id
+"""
+
+NO_WS_MESSY_ROW_SQL = """
+(
+    1,
+    '12 HIGH ROAD',
+    '12 HIGH ROAD',
+    'AA1 1AA',
+    CAST([] AS VARCHAR[]),
+    ARRAY['12', '10']::VARCHAR[],
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    1::BIGINT
+)
+"""
+
+NO_WS_CANONICAL_ROW_SQL = """
+(
+    1001,
+    '12HIGHROAD',
+    '12HIGHROAD',
+    'AA1 1AA',
+    CAST([] AS VARCHAR[]),
+    ARRAY['12']::VARCHAR[],
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    10::BIGINT
+)
+"""
+
+FLAT_MESSY_ROW_SQL = """
+(
+    1,
+    'FLAT 2 10 HIGH STREET',
+    'FLAT 2 10 HIGH STREET',
+    'AA1 1AA',
+    CAST([] AS VARCHAR[]),
+    ARRAY['2', '10']::VARCHAR[],
+    TRUE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    '2',
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    1::BIGINT
+)
+"""
+
+FLAT_CANONICAL_ROW_SQL = """
+(
+    1002,
+    '2 10 HIGH STREET',
+    '2 10 HIGH STREET',
+    'AA1 1AA',
+    CAST([] AS VARCHAR[]),
+    ARRAY['2', '10']::VARCHAR[],
+    TRUE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    '2',
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    20::BIGINT
+)
+"""
+
+FLAT_CANONICAL_DUPLICATE_ROW_SQL = """
+(
+    1002,
+    '2 10 HIGH STREET',
+    '2 10 HIGH STREET',
+    'AA1 1AA',
+    CAST([] AS VARCHAR[]),
+    ARRAY['2', '10']::VARCHAR[],
+    TRUE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    '2',
+    FALSE,
+    NULL::VARCHAR,
+    NULL::VARCHAR,
+    21::BIGINT
+)
+"""
+
+
+def _address_relation_from_values(duck_con, values_sql: str):
+    return duck_con.sql(
+        f"""
+        SELECT *
+        FROM (
+            VALUES
+                {values_sql}
+        ) AS t(
+            {ADDRESS_ROW_COLUMNS_SQL}
         )
         """
     )
+
+
+def test_exact_matching_applies_no_whitespace_fallback_by_default(duck_con):
+    df_messy = _address_relation_from_values(duck_con, NO_WS_MESSY_ROW_SQL)
+    df_canonical = _address_relation_from_values(duck_con, NO_WS_CANONICAL_ROW_SQL)
 
     results, _ = _run_matching(
         con=duck_con,
@@ -201,6 +267,52 @@ def test_exact_matching_applies_no_whitespace_fallback_by_default(duck_con):
     row = results.fetchdf().iloc[0]
     assert row["resolved_canonical_id"] == 1001
     assert row["match_reason"] == MatchReason.EXACT_NO_WHITESPACE.value
+
+
+def test_exact_matching_applies_flat_retraction_with_heuristics(duck_con):
+    df_messy = _address_relation_from_values(duck_con, FLAT_MESSY_ROW_SQL)
+    df_canonical = _address_relation_from_values(duck_con, FLAT_CANONICAL_ROW_SQL)
+
+    results, _ = _run_matching(
+        con=duck_con,
+        df_messy_clean=df_messy,
+        df_canonical_clean=df_canonical,
+        stages=[ExactMatchStage()],
+    )
+    row = results.fetchdf().iloc[0]
+    assert row["resolved_canonical_id"] == 1002
+    assert row["match_reason"] == MatchReason.EXACT_FLAT_RETRACTION.value
+
+
+def test_exact_matching_skips_flat_retraction_when_disabled(duck_con):
+    df_messy = _address_relation_from_values(duck_con, FLAT_MESSY_ROW_SQL)
+    df_canonical = _address_relation_from_values(duck_con, FLAT_CANONICAL_ROW_SQL)
+
+    results, _ = _run_matching(
+        con=duck_con,
+        df_messy_clean=df_messy,
+        df_canonical_clean=df_canonical,
+        stages=[ExactMatchStage(enable_flat_retraction=False)],
+    )
+    matched = results.fetchdf().dropna(subset=["resolved_canonical_id"])
+    assert matched.empty
+
+
+def test_exact_matching_flat_retraction_requires_unique_canonical_row(duck_con):
+    df_messy = _address_relation_from_values(duck_con, FLAT_MESSY_ROW_SQL)
+    df_canonical = _address_relation_from_values(
+        duck_con,
+        f"{FLAT_CANONICAL_ROW_SQL},\n{FLAT_CANONICAL_DUPLICATE_ROW_SQL}",
+    )
+
+    results, _ = _run_matching(
+        con=duck_con,
+        df_messy_clean=df_messy,
+        df_canonical_clean=df_canonical,
+        stages=[ExactMatchStage()],
+    )
+    matched = results.fetchdf().dropna(subset=["resolved_canonical_id"])
+    assert matched.empty
 
 
 # -----------------------------------------------------------------------------

--- a/uk_address_matcher/linking_model/matching/stages/exact_match.py
+++ b/uk_address_matcher/linking_model/matching/stages/exact_match.py
@@ -18,6 +18,63 @@ if TYPE_CHECKING:
 MessyInputName = Literal["__ukam__tmp_messy_addresses", "unmatched_records"]
 
 
+def _remove_flat_keyword_sql(column_reference: str) -> str:
+    """Return SQL that strips standalone FLAT and re-normalises spaces."""
+
+    return f"""
+        TRIM(
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(
+                    ' ' || {column_reference} || ' ',
+                    '\\bFLAT\\b',
+                    ' ',
+                    'g'
+                ),
+                '\\s+',
+                ' ',
+                'g'
+            )
+        )
+    """
+
+
+def _flat_field_compatibility_sql() -> str:
+    """Return SQL requiring flat fields to be non-contradictory."""
+
+    return """
+       (
+           messy.flat_number IS NULL
+           OR canon.flat_number IS NULL
+           OR messy.flat_number = canon.flat_number
+       )
+       AND (
+           messy.flat_letter IS NULL
+           OR canon.flat_letter IS NULL
+           OR messy.flat_letter = canon.flat_letter
+       )
+       AND (
+           messy.flat_positional IS NULL
+           OR canon.flat_positional IS NULL
+           OR messy.flat_positional = canon.flat_positional
+       )
+    """
+
+
+def _flat_retraction_unit_evidence_sql(alias: str) -> str:
+    """Return SQL for independent sub-unit evidence using parsed columns."""
+
+    return f"""
+        (
+            {alias}.flat_number IS NOT NULL
+            OR {alias}.flat_letter IS NOT NULL
+            OR {alias}.flat_positional IS NOT NULL
+            OR COALESCE({alias}.has_business_unit, FALSE)
+            OR {alias}.business_unit_id IS NOT NULL
+            OR COALESCE(array_length({alias}.numeric_tokens), 0) >= 2
+        )
+    """
+
+
 @dataclass(frozen=True, repr=False)
 class ExactMatchStage(MatchingStage):
     """Deterministic exact matching on ``clean_full_address`` and ``postcode``.
@@ -33,7 +90,17 @@ class ExactMatchStage(MatchingStage):
         ``"10 Demo Road Townton"`` matches
         ``"10 Demo Road, Townton"`` only when cleaning normalises punctuation
         and whitespace and both records have the same postcode.
+
+    This stage applies three deterministic phases in priority order:
+    1. exact ``clean_full_address + postcode``
+    2. exact after removing all whitespace
+    3. exact after removing standalone ``FLAT``, gated by parsed-unit
+       heuristics and flat-field compatibility checks
+
+    Set ``enable_flat_retraction=False`` to skip phase 3.
     """
+
+    enable_flat_retraction: bool = True
 
     def find_matches(
         self,
@@ -52,7 +119,10 @@ class ExactMatchStage(MatchingStage):
             con=con,
             pipeline_stages=[
                 _restrict_canonical_to_messy_postcodes("exact"),
-                _exact_matches("__ukam__tmp_messy_addresses"),
+                _exact_matches(
+                    "__ukam__tmp_messy_addresses",
+                    enable_flat_retraction=self.enable_flat_retraction,
+                ),
             ],
             stage_name=stage_name,
             df_unmatched=df_unmatched,
@@ -70,12 +140,13 @@ class ExactMatchStage(MatchingStage):
 )
 def _exact_matches(
     messy_input_name: MessyInputName = "__ukam__tmp_messy_addresses",
+    *,
+    enable_flat_retraction: bool = True,
 ) -> list[CTEStep]:
-    """Find exact and no-whitespace postcode-bounded matches.
+    """Find deterministic matches using exact, no-whitespace and FLAT phases.
 
-    Uses set-based equality joins and then selects one deterministic best
-    candidate per messy record, preferring exact matches over no-whitespace
-    matches.
+    Phases 1 and 2 are selected by ranked preference. Phase 3 applies only to
+    records still unmatched after phases 1 and 2.
 
     Parameters
     ----------
@@ -83,18 +154,18 @@ def _exact_matches(
         The placeholder name for the messy input table. Defaults to
         "__ukam__tmp_messy_addresses" for the initial pass. Can be set
         to "unmatched_records" when running after filtering.
+    enable_flat_retraction:
+        If ``True``, run phase 3 and emit
+        ``exact_flat_retraction: match after removing FLAT keyword`` when it
+        yields an unambiguous candidate. If ``False``, skip phase 3.
     """
-    exact_match_condition = """
-        messy.clean_full_address = canon.clean_full_address
-        AND messy.postcode = canon.postcode
-    """
-
+    no_ws_expression = "regexp_replace(clean_full_address, '\\s+', '', 'g')"
     exact_value = MatchReason.EXACT.value
     exact_no_whitespace_value = MatchReason.EXACT_NO_WHITESPACE.value
+    exact_flat_retraction_value = MatchReason.EXACT_FLAT_RETRACTION.value
     enum_values = str(MatchReason.enum_values())
-    no_ws_expression = "regexp_replace(clean_full_address, '\\s+', '', 'g')"
 
-    messy_match_keys_sql = f"""
+    messy_keys_sql = f"""
         SELECT
             messy.ukam_address_id,
             messy.postcode,
@@ -103,7 +174,7 @@ def _exact_matches(
         FROM {{{messy_input_name}}} AS messy
     """
 
-    canonical_match_keys_sql = f"""
+    canon_keys_sql = f"""
         SELECT
             canon.ukam_address_id AS canonical_ukam_address_id,
             canon.canonical_unique_id,
@@ -120,9 +191,10 @@ def _exact_matches(
             canon.canonical_unique_id AS resolved_canonical_id,
             '{exact_value}'::ENUM {enum_values} AS match_reason,
             1 AS match_priority
-        FROM {{messy_match_keys}} AS messy
-        INNER JOIN {{canonical_match_keys}} AS canon
-            ON {exact_match_condition}
+        FROM {{messy_keys}} AS messy
+        INNER JOIN {{canon_keys}} AS canon
+            ON messy.clean_full_address = canon.clean_full_address
+            AND messy.postcode = canon.postcode
     """
 
     no_ws_candidates_sql = f"""
@@ -132,21 +204,21 @@ def _exact_matches(
             canon.canonical_unique_id AS resolved_canonical_id,
             '{exact_no_whitespace_value}'::ENUM {enum_values} AS match_reason,
             2 AS match_priority
-        FROM {{messy_match_keys}} AS messy
-        INNER JOIN {{canonical_match_keys}} AS canon
+        FROM {{messy_keys}} AS messy
+        INNER JOIN {{canon_keys}} AS canon
             ON messy.postcode = canon.postcode
             AND messy.clean_full_address_no_ws = canon.clean_full_address_no_ws
-            AND messy.clean_full_address_no_ws <> ''
             AND messy.clean_full_address <> canon.clean_full_address
+            AND messy.clean_full_address_no_ws <> ''
     """
 
-    all_exact_candidates_sql = """
+    all_ranked_candidates_sql = """
         SELECT * FROM {exact_candidates}
         UNION ALL
         SELECT * FROM {no_ws_candidates}
     """
 
-    ranked_exact_candidates_sql = """
+    ranked_pre_flat_candidates_sql = """
         SELECT
             candidates.ukam_address_id,
             candidates.canonical_ukam_address_id,
@@ -158,25 +230,142 @@ def _exact_matches(
                     candidates.match_priority,
                     candidates.canonical_ukam_address_id
             ) AS rn
-        FROM {all_exact_candidates} AS candidates
+        FROM {all_ranked_candidates} AS candidates
     """
 
-    exact_matches_sql = """
+    pre_flat_matches_sql = """
         SELECT
             ukam_address_id,
             canonical_ukam_address_id,
             resolved_canonical_id,
             match_reason
-        FROM {ranked_exact_candidates}
+        FROM {ranked_pre_flat_candidates}
         WHERE rn = 1
     """
 
-    return [
-        CTEStep("messy_match_keys", messy_match_keys_sql),
-        CTEStep("canonical_match_keys", canonical_match_keys_sql),
+    steps = [
+        CTEStep("messy_keys", messy_keys_sql),
+        CTEStep("canon_keys", canon_keys_sql),
         CTEStep("exact_candidates", exact_candidates_sql),
         CTEStep("no_ws_candidates", no_ws_candidates_sql),
-        CTEStep("all_exact_candidates", all_exact_candidates_sql),
-        CTEStep("ranked_exact_candidates", ranked_exact_candidates_sql),
-        CTEStep("exact_matches", exact_matches_sql),
+        CTEStep("all_ranked_candidates", all_ranked_candidates_sql),
+        CTEStep("ranked_pre_flat_candidates", ranked_pre_flat_candidates_sql),
+        CTEStep("pre_flat_matches", pre_flat_matches_sql),
     ]
+
+    if enable_flat_retraction:
+        flat_compatibility_condition = _flat_field_compatibility_sql()
+        messy_no_flat_expression = _remove_flat_keyword_sql("messy.clean_full_address")
+        canon_no_flat_expression = _remove_flat_keyword_sql("canon.clean_full_address")
+
+        messy_flat_keys_sql = f"""
+            SELECT
+                messy.ukam_address_id,
+                messy.postcode,
+                messy.clean_full_address,
+                {messy_no_flat_expression} AS clean_full_address_no_flat,
+                messy.flat_number,
+                messy.flat_letter,
+                messy.flat_positional,
+                messy.has_business_unit,
+                messy.business_unit_id,
+                messy.numeric_tokens
+            FROM {{{messy_input_name}}} AS messy
+        """
+
+        canon_flat_keys_sql = f"""
+            SELECT
+                canon.ukam_address_id AS canonical_ukam_address_id,
+                canon.canonical_unique_id,
+                canon.postcode,
+                canon.clean_full_address,
+                {canon_no_flat_expression} AS clean_full_address_no_flat,
+                canon.flat_number,
+                canon.flat_letter,
+                canon.flat_positional,
+                canon.has_business_unit,
+                canon.business_unit_id,
+                canon.numeric_tokens
+            FROM {{canonical_addresses_restricted}} AS canon
+        """
+
+        unmatched_after_pre_flat_sql = """
+            SELECT
+                messy.*
+            FROM {messy_flat_keys} AS messy
+            LEFT JOIN {pre_flat_matches} AS matched
+                ON matched.ukam_address_id = messy.ukam_address_id
+            WHERE matched.ukam_address_id IS NULL
+        """
+
+        canon_flat_unique_sql = """
+            SELECT
+                canon.postcode,
+                canon.clean_full_address_no_flat,
+                MIN(canon.canonical_ukam_address_id) AS canonical_ukam_address_id,
+                MIN(canon.canonical_unique_id) AS resolved_canonical_id,
+                MIN(canon.flat_number) AS flat_number,
+                MIN(canon.flat_letter) AS flat_letter,
+                MIN(canon.flat_positional) AS flat_positional,
+                BOOL_OR(COALESCE(canon.has_business_unit, FALSE)) AS has_business_unit,
+                MIN(canon.business_unit_id) AS business_unit_id,
+                BOOL_OR(
+                    canon.clean_full_address_no_flat <> canon.clean_full_address
+                ) AS canonical_flat_keyword_removed,
+                BOOL_OR(
+                    canon.flat_number IS NOT NULL
+                    OR canon.flat_letter IS NOT NULL
+                    OR canon.flat_positional IS NOT NULL
+                    OR COALESCE(canon.has_business_unit, FALSE)
+                    OR canon.business_unit_id IS NOT NULL
+                    OR COALESCE(array_length(canon.numeric_tokens), 0) >= 2
+                ) AS canonical_has_unit_evidence
+            FROM {canon_flat_keys} AS canon
+            WHERE canon.clean_full_address_no_flat <> ''
+            GROUP BY canon.postcode, canon.clean_full_address_no_flat
+            HAVING COUNT(DISTINCT canon.canonical_ukam_address_id) = 1
+        """
+
+        flat_retraction_matches_sql = f"""
+            SELECT
+                messy.ukam_address_id,
+                canon.canonical_ukam_address_id,
+                canon.resolved_canonical_id,
+                '{exact_flat_retraction_value}'::ENUM {enum_values} AS match_reason
+            FROM {{unmatched_after_pre_flat}} AS messy
+            INNER JOIN {{canon_flat_unique}} AS canon
+                ON messy.postcode = canon.postcode
+                AND messy.clean_full_address_no_flat = canon.clean_full_address_no_flat
+            WHERE messy.clean_full_address_no_flat <> ''
+            AND (
+                messy.clean_full_address_no_flat <> messy.clean_full_address
+                OR COALESCE(canon.canonical_flat_keyword_removed, FALSE)
+            )
+            AND {flat_compatibility_condition}
+            AND (
+                {_flat_retraction_unit_evidence_sql("messy")}
+                OR COALESCE(canon.canonical_has_unit_evidence, FALSE)
+            )
+        """
+
+        steps.extend(
+            [
+                CTEStep("messy_flat_keys", messy_flat_keys_sql),
+                CTEStep("canon_flat_keys", canon_flat_keys_sql),
+                CTEStep("unmatched_after_pre_flat", unmatched_after_pre_flat_sql),
+                CTEStep("canon_flat_unique", canon_flat_unique_sql),
+                CTEStep("flat_retraction_matches", flat_retraction_matches_sql),
+            ]
+        )
+
+        exact_matches_sql = """
+            SELECT * FROM {pre_flat_matches}
+            UNION ALL
+            SELECT * FROM {flat_retraction_matches}
+        """
+    else:
+        exact_matches_sql = "SELECT * FROM {pre_flat_matches}"
+
+    steps.append(CTEStep("exact_matches", exact_matches_sql))
+
+    return steps

--- a/uk_address_matcher/linking_model/matching/stages/exact_match.py
+++ b/uk_address_matcher/linking_model/matching/stages/exact_match.py
@@ -18,26 +18,6 @@ if TYPE_CHECKING:
 MessyInputName = Literal["__ukam__tmp_messy_addresses", "unmatched_records"]
 
 
-def _remove_flat_keyword_sql(column_reference: str) -> str:
-    """Return SQL that strips standalone FLAT and re-normalises spaces."""
-
-    return f"""
-        TRIM(
-            REGEXP_REPLACE(
-                REGEXP_REPLACE(
-                    ' ' || {column_reference} || ' ',
-                    '\\bFLAT\\b',
-                    ' ',
-                    'g'
-                ),
-                '\\s+',
-                ' ',
-                'g'
-            )
-        )
-    """
-
-
 def _flat_field_compatibility_sql() -> str:
     """Return SQL requiring flat fields to be non-contradictory."""
 
@@ -94,8 +74,8 @@ class ExactMatchStage(MatchingStage):
     This stage applies three deterministic phases in priority order:
     1. exact ``clean_full_address + postcode``
     2. exact after removing all whitespace
-    3. exact after removing standalone ``FLAT``, gated by parsed-unit
-       heuristics and flat-field compatibility checks
+    3. exact after removing standalone ``FLAT`` *and* all whitespace, gated by
+       parsed-unit heuristics and flat-field compatibility checks
 
     Set ``enable_flat_retraction=False`` to skip phase 3.
     """
@@ -159,29 +139,92 @@ def _exact_matches(
         ``exact_flat_retraction: match after removing FLAT keyword`` when it
         yields an unambiguous candidate. If ``False``, skip phase 3.
     """
-    no_ws_expression = "regexp_replace(clean_full_address, '\\s+', '', 'g')"
     exact_value = MatchReason.EXACT.value
     exact_no_whitespace_value = MatchReason.EXACT_NO_WHITESPACE.value
     exact_flat_retraction_value = MatchReason.EXACT_FLAT_RETRACTION.value
     enum_values = str(MatchReason.enum_values())
 
-    messy_keys_sql = f"""
+    # Both messy_keys and canon_keys compute every derived key (plus the flat
+    # metadata phase 3 needs) in a single pass so we never rescan the source
+    # relation. Phase 3 reads from the same CTEs as phases 1 & 2.
+    #
+    # Key derivation strategy (one regex pass per row when FLAT is absent):
+    #   clean_full_address_no_ws         : strip whitespace only
+    #   clean_full_address_no_flat_no_ws : strip FLAT + whitespace, via an
+    #       alternation regex gated by a cheap contains() check. When no
+    #       "FLAT" token is present the column degrades to the no-ws value
+    #       with no extra regex work.
+    _flat_metadata_messy_sql = (
+        ",\n                messy.flat_number,"
+        "\n                messy.flat_letter,"
+        "\n                messy.flat_positional,"
+        "\n                messy.has_business_unit,"
+        "\n                messy.business_unit_id,"
+        "\n                messy.numeric_tokens"
+        if enable_flat_retraction
+        else ""
+    )
+    _flat_metadata_canon_sql = (
+        ",\n                canon.flat_number,"
+        "\n                canon.flat_letter,"
+        "\n                canon.flat_positional,"
+        "\n                canon.has_business_unit,"
+        "\n                canon.business_unit_id,"
+        "\n                canon.numeric_tokens"
+        if enable_flat_retraction
+        else ""
+    )
+    _flat_key_sql = (
+        r""",
+            CASE
+                WHEN contains(base.clean_full_address, 'FLAT')
+                THEN regexp_replace(
+                    base.clean_full_address, '\bFLAT\b|\s+', '', 'g'
+                )
+                ELSE base.clean_full_address_no_ws
+            END AS clean_full_address_no_flat_no_ws"""
+        if enable_flat_retraction
+        else ""
+    )
+
+    messy_keys_sql = rf"""
         SELECT
-            messy.ukam_address_id,
-            messy.postcode,
-            messy.clean_full_address,
-            {no_ws_expression} AS clean_full_address_no_ws
-        FROM {{{messy_input_name}}} AS messy
+            base.ukam_address_id,
+            base.postcode,
+            base.clean_full_address,
+            base.clean_full_address_no_ws{_flat_key_sql}
+            {"," if enable_flat_retraction else ""}
+            {"base.flat_number, base.flat_letter, base.flat_positional, base.has_business_unit, base.business_unit_id, base.numeric_tokens" if enable_flat_retraction else ""}
+        FROM (
+            SELECT
+                messy.ukam_address_id,
+                messy.postcode,
+                messy.clean_full_address,
+                regexp_replace(messy.clean_full_address, '\s+', '', 'g')
+                    AS clean_full_address_no_ws{_flat_metadata_messy_sql}
+            FROM {{{messy_input_name}}} AS messy
+        ) AS base
     """
 
-    canon_keys_sql = f"""
+    canon_keys_sql = rf"""
         SELECT
-            canon.ukam_address_id AS canonical_ukam_address_id,
-            canon.canonical_unique_id,
-            canon.postcode,
-            canon.clean_full_address,
-            {no_ws_expression} AS clean_full_address_no_ws
-        FROM {{canonical_addresses_restricted}} AS canon
+            base.canonical_ukam_address_id,
+            base.canonical_unique_id,
+            base.postcode,
+            base.clean_full_address,
+            base.clean_full_address_no_ws{_flat_key_sql}
+            {"," if enable_flat_retraction else ""}
+            {"base.flat_number, base.flat_letter, base.flat_positional, base.has_business_unit, base.business_unit_id, base.numeric_tokens" if enable_flat_retraction else ""}
+        FROM (
+            SELECT
+                canon.ukam_address_id AS canonical_ukam_address_id,
+                canon.canonical_unique_id,
+                canon.postcode,
+                canon.clean_full_address,
+                regexp_replace(canon.clean_full_address, '\s+', '', 'g')
+                    AS clean_full_address_no_ws{_flat_metadata_canon_sql}
+            FROM {{canonical_addresses_restricted}} AS canon
+        ) AS base
     """
 
     exact_candidates_sql = f"""
@@ -255,53 +298,37 @@ def _exact_matches(
 
     if enable_flat_retraction:
         flat_compatibility_condition = _flat_field_compatibility_sql()
-        messy_no_flat_expression = _remove_flat_keyword_sql("messy.clean_full_address")
-        canon_no_flat_expression = _remove_flat_keyword_sql("canon.clean_full_address")
 
-        messy_flat_keys_sql = f"""
-            SELECT
-                messy.ukam_address_id,
-                messy.postcode,
-                messy.clean_full_address,
-                {messy_no_flat_expression} AS clean_full_address_no_flat,
-                messy.flat_number,
-                messy.flat_letter,
-                messy.flat_positional,
-                messy.has_business_unit,
-                messy.business_unit_id,
-                messy.numeric_tokens
-            FROM {{{messy_input_name}}} AS messy
-        """
-
-        canon_flat_keys_sql = f"""
-            SELECT
-                canon.ukam_address_id AS canonical_ukam_address_id,
-                canon.canonical_unique_id,
-                canon.postcode,
-                canon.clean_full_address,
-                {canon_no_flat_expression} AS clean_full_address_no_flat,
-                canon.flat_number,
-                canon.flat_letter,
-                canon.flat_positional,
-                canon.has_business_unit,
-                canon.business_unit_id,
-                canon.numeric_tokens
-            FROM {{canonical_addresses_restricted}} AS canon
-        """
-
-        unmatched_after_pre_flat_sql = """
-            SELECT
-                messy.*
-            FROM {messy_flat_keys} AS messy
+        # Phase 3 reuses the already-projected messy_keys / canon_keys CTEs —
+        # no second scan of the source relations, no duplicate regex work.
+        # Residual messy rows are the ones that didn't match in phases 1-2.
+        messy_flat_keys_sql = """
+            SELECT messy.*
+            FROM {messy_keys} AS messy
             LEFT JOIN {pre_flat_matches} AS matched
                 ON matched.ukam_address_id = messy.ukam_address_id
             WHERE matched.ukam_address_id IS NULL
         """
 
+        # Canonical is already postcode-restricted to the full messy set by
+        # canonical_addresses_restricted; narrowing further to residual
+        # postcodes shrinks the phase-3 dedupe GROUP BY.
+        residual_postcodes_sql = """
+            SELECT DISTINCT postcode
+            FROM {messy_flat_keys}
+        """
+
+        canon_flat_keys_sql = """
+            SELECT canon.*
+            FROM {canon_keys} AS canon
+            SEMI JOIN {residual_postcodes} AS rp
+                ON rp.postcode = canon.postcode
+        """
+
         canon_flat_unique_sql = """
             SELECT
                 canon.postcode,
-                canon.clean_full_address_no_flat,
+                canon.clean_full_address_no_flat_no_ws,
                 MIN(canon.canonical_ukam_address_id) AS canonical_ukam_address_id,
                 MIN(canon.canonical_unique_id) AS resolved_canonical_id,
                 MIN(canon.flat_number) AS flat_number,
@@ -310,7 +337,8 @@ def _exact_matches(
                 BOOL_OR(COALESCE(canon.has_business_unit, FALSE)) AS has_business_unit,
                 MIN(canon.business_unit_id) AS business_unit_id,
                 BOOL_OR(
-                    canon.clean_full_address_no_flat <> canon.clean_full_address
+                    canon.clean_full_address_no_flat_no_ws
+                        <> canon.clean_full_address_no_ws
                 ) AS canonical_flat_keyword_removed,
                 BOOL_OR(
                     canon.flat_number IS NOT NULL
@@ -321,8 +349,8 @@ def _exact_matches(
                     OR COALESCE(array_length(canon.numeric_tokens), 0) >= 2
                 ) AS canonical_has_unit_evidence
             FROM {canon_flat_keys} AS canon
-            WHERE canon.clean_full_address_no_flat <> ''
-            GROUP BY canon.postcode, canon.clean_full_address_no_flat
+            WHERE canon.clean_full_address_no_flat_no_ws <> ''
+            GROUP BY canon.postcode, canon.clean_full_address_no_flat_no_ws
             HAVING COUNT(DISTINCT canon.canonical_ukam_address_id) = 1
         """
 
@@ -332,13 +360,15 @@ def _exact_matches(
                 canon.canonical_ukam_address_id,
                 canon.resolved_canonical_id,
                 '{exact_flat_retraction_value}'::ENUM {enum_values} AS match_reason
-            FROM {{unmatched_after_pre_flat}} AS messy
+            FROM {{messy_flat_keys}} AS messy
             INNER JOIN {{canon_flat_unique}} AS canon
                 ON messy.postcode = canon.postcode
-                AND messy.clean_full_address_no_flat = canon.clean_full_address_no_flat
-            WHERE messy.clean_full_address_no_flat <> ''
+                AND messy.clean_full_address_no_flat_no_ws
+                    = canon.clean_full_address_no_flat_no_ws
+            WHERE messy.clean_full_address_no_flat_no_ws <> ''
             AND (
-                messy.clean_full_address_no_flat <> messy.clean_full_address
+                messy.clean_full_address_no_flat_no_ws
+                    <> messy.clean_full_address_no_ws
                 OR COALESCE(canon.canonical_flat_keyword_removed, FALSE)
             )
             AND {flat_compatibility_condition}
@@ -351,8 +381,8 @@ def _exact_matches(
         steps.extend(
             [
                 CTEStep("messy_flat_keys", messy_flat_keys_sql),
+                CTEStep("residual_postcodes", residual_postcodes_sql),
                 CTEStep("canon_flat_keys", canon_flat_keys_sql),
-                CTEStep("unmatched_after_pre_flat", unmatched_after_pre_flat_sql),
                 CTEStep("canon_flat_unique", canon_flat_unique_sql),
                 CTEStep("flat_retraction_matches", flat_retraction_matches_sql),
             ]

--- a/uk_address_matcher/linking_model/matching/stages/exact_match.py
+++ b/uk_address_matcher/linking_model/matching/stages/exact_match.py
@@ -174,6 +174,17 @@ def _exact_matches(
         if enable_flat_retraction
         else ""
     )
+    _flat_extra_cols_sql = (
+        """,
+            base.flat_number,
+            base.flat_letter,
+            base.flat_positional,
+            base.has_business_unit,
+            base.business_unit_id,
+            base.numeric_tokens"""
+        if enable_flat_retraction
+        else ""
+    )
     _flat_key_sql = (
         r""",
             CASE
@@ -192,9 +203,7 @@ def _exact_matches(
             base.ukam_address_id,
             base.postcode,
             base.clean_full_address,
-            base.clean_full_address_no_ws{_flat_key_sql}
-            {"," if enable_flat_retraction else ""}
-            {"base.flat_number, base.flat_letter, base.flat_positional, base.has_business_unit, base.business_unit_id, base.numeric_tokens" if enable_flat_retraction else ""}
+            base.clean_full_address_no_ws{_flat_key_sql}{_flat_extra_cols_sql}
         FROM (
             SELECT
                 messy.ukam_address_id,
@@ -212,9 +221,7 @@ def _exact_matches(
             base.canonical_unique_id,
             base.postcode,
             base.clean_full_address,
-            base.clean_full_address_no_ws{_flat_key_sql}
-            {"," if enable_flat_retraction else ""}
-            {"base.flat_number, base.flat_letter, base.flat_positional, base.has_business_unit, base.business_unit_id, base.numeric_tokens" if enable_flat_retraction else ""}
+            base.clean_full_address_no_ws{_flat_key_sql}{_flat_extra_cols_sql}
         FROM (
             SELECT
                 canon.ukam_address_id AS canonical_ukam_address_id,

--- a/uk_address_matcher/sql_pipeline/match_reasons.py
+++ b/uk_address_matcher/sql_pipeline/match_reasons.py
@@ -8,9 +8,7 @@ class MatchReason(Enum):
 
     EXACT = "exact: full match"
     EXACT_NO_WHITESPACE = "exact_no_whitespace: full match after removing whitespace"
-    EXACT_FLAT_RETRACTION = (
-        "exact_flat_retraction: match after removing FLAT keyword"
-    )
+    EXACT_FLAT_RETRACTION = "exact_flat_retraction: match after removing FLAT keyword"
     PEELED_ADDRESS = "peeled_address: match after removing common UK end tokens"
     SPLINK = "splink: probabilistic match"
     UNIQUE_TRIGRAM = "unique_trigram: unique trigram match"

--- a/uk_address_matcher/sql_pipeline/match_reasons.py
+++ b/uk_address_matcher/sql_pipeline/match_reasons.py
@@ -8,6 +8,9 @@ class MatchReason(Enum):
 
     EXACT = "exact: full match"
     EXACT_NO_WHITESPACE = "exact_no_whitespace: full match after removing whitespace"
+    EXACT_FLAT_RETRACTION = (
+        "exact_flat_retraction: match after removing FLAT keyword"
+    )
     PEELED_ADDRESS = "peeled_address: match after removing common UK end tokens"
     SPLINK = "splink: probabilistic match"
     UNIQUE_TRIGRAM = "unique_trigram: unique trigram match"
@@ -22,6 +25,8 @@ class MatchReason(Enum):
             return "exact_matches"
         if self is MatchReason.EXACT_NO_WHITESPACE:
             return "exact_no_whitespace"
+        if self is MatchReason.EXACT_FLAT_RETRACTION:
+            return "exact_flat_retraction"
         if self is MatchReason.PEELED_ADDRESS:
             return "peeled_address"
         if self is MatchReason.SPLINK:


### PR DESCRIPTION
- Add SQL functions to strip standalone FLAT keywords and normalise spaces.
- Introduce flat field compatibility checks for improved matching accuracy.
- Update matching phases to include flat retraction logic, gated by configuration.
- Extend MatchReason enum to include exact flat retraction match reason.

This allows us to exact match where we are missing `FLAT` on one side more easily, whilst keeping a heuristic that tries to guarantee we will only strip on "flat-like" entities. The logic for "flat-like" selection is [here](https://github.com/moj-analytical-services/uk_address_matcher/blob/ec5fd3efc80b655541d1290b1cd391b18ce04fcc/uk_address_matcher/linking_model/matching/stages/exact_match.py#L43-L55).

For Hackney this yields:
<img width="938" height="735" alt="Screenshot 2026-04-18 at 10 09 46" src="https://github.com/user-attachments/assets/43c42d3f-3621-4be1-a8b6-4d281c132150" />

This techniques allows us to capture about 6k records in the exact matching phase for Hackney and increases our overall precision as a result.
<img width="1178" height="445" alt="Screenshot 2026-04-18 at 10 10 36" src="https://github.com/user-attachments/assets/243a197d-6e7f-4629-bc3a-3570235c6296" />

I've manually gone through all of the new "incorrect" matches for Hackney, Lambeth and Aberdeenshire and they all appear to be incorrect source labels.

We should look at also experimenting with removing other common words which don't add value to the address string such as 'AT' and 'THE' at some point.