### PR TITLE
feat: add parsing for other flat variations

### DIFF
--- a/uk_address_matcher/cleaning/steps/normalisation.py
+++ b/uk_address_matcher/cleaning/steps/normalisation.py
@@ -303,7 +303,9 @@ def _normalise_abbreviations_and_units() -> list[CTEStep]:
 
     Also normalise unit types using a vectorised map lookup.
 
-    - 1. Load lookup (upper-case keys for case-insensitive match)
+    - 1. Load lookup (upper-case keys for case-insensitive match), extended with
+         generated compact-floor rows so the JSON file only carries genuinely
+         arbitrary abbreviations.
     - 2. Build a single-row MAP (hashmap) using list aggregations
     - 3. Vectorised transform over token list, then join back to a string
     """
@@ -311,6 +313,35 @@ def _normalise_abbreviations_and_units() -> list[CTEStep]:
     read_abbr_sql = package_resource_read_sql(
         "uk_address_matcher.data", "address_abbreviations.json"
     )
+
+    # Compact-floor tokens are a regular cartesian product: floor code x suffix.
+    # Forward slashes are already normalised to dashes by an earlier cleaning
+    # pass, so only dash forms need expanding here.
+    floor_names = [
+        "GROUND",
+        "FIRST",
+        "SECOND",
+        "THIRD",
+        "FOURTH",
+        "FIFTH",
+        "SIXTH",
+        "SEVENTH",
+        "EIGHTH",
+        "NINTH",
+        "TENTH",
+    ]
+    floor_codes = ["G"] + [str(i) for i in range(1, len(floor_names))]
+    compact_floor_rows: list[tuple[str, str]] = []
+    for code, name in zip(floor_codes, floor_names):
+        compact_floor_rows.append((f"{code}FR", f"{name} FLOOR"))
+        compact_floor_rows.append((f"{code}F-R", f"{name} FLOOR RIGHT"))
+        compact_floor_rows.append((f"{code}F-L", f"{name} FLOOR LEFT"))
+        compact_floor_rows.append((f"{code}R-R", f"{name} FLOOR RIGHT"))
+        compact_floor_rows.append((f"{code}L-L", f"{name} FLOOR LEFT"))
+    compact_floor_values = ", ".join(
+        f"('{token}', '{replacement}')" for token, replacement in compact_floor_rows
+    )
+
     # 1) Load lookup (upper-case keys for case-insensitive match)
     abbr_lookup_sql = f"""
     SELECT
@@ -318,6 +349,9 @@ def _normalise_abbreviations_and_units() -> list[CTEStep]:
         TRIM(replacement)        AS replacement
     FROM ({read_abbr_sql})
     WHERE token IS NOT NULL AND replacement IS NOT NULL
+    UNION ALL
+    SELECT token, replacement
+    FROM (VALUES {compact_floor_values}) AS compact_floors(token, replacement)
     """
 
     # 2) Build a single-row MAP using list aggregations (works on DuckDB without map_agg)

--- a/uk_address_matcher/cleaning/steps/token_parsing.py
+++ b/uk_address_matcher/cleaning/steps/token_parsing.py
@@ -165,6 +165,7 @@ def _parse_out_flat_position_and_letter():
         "SEVENTH",
         "EIGHTH",
         "NINTH",
+        "TENTH",
         "TOP",
     ]
     # Build regex: standalone floors OR (prefix + FLOOR) OR
@@ -174,9 +175,9 @@ def _parse_out_flat_position_and_letter():
     # Pattern handles: WORD, or WORD (space) or AND, followed by final floor + FLOORS
     multi_floor_pattern = (
         r"(?:(?:GROUND|FIRST|SECOND|THIRD|FOURTH|FIFTH|SIXTH|"
-        r"SEVENTH|EIGHTH|NINTH|TOP),? ?|AND )*"
+        r"SEVENTH|EIGHTH|NINTH|TENTH|TOP),? ?|AND )*"
         r"(?:GROUND|FIRST|SECOND|THIRD|FOURTH|FIFTH|SIXTH|"
-        r"SEVENTH|EIGHTH|NINTH|TOP) FLOORS"
+        r"SEVENTH|EIGHTH|NINTH|TENTH|TOP) FLOORS"
     )
     floor_positions = (
         r"\b("
@@ -188,6 +189,18 @@ def _parse_out_flat_position_and_letter():
         + r"|"
         + multi_floor_pattern
         + r")\b"
+    )
+    leading_bare_floor_position = (
+        r"^\s*(GROUND|FIRST|SECOND|THIRD|FOURTH|FIFTH|SIXTH|"
+        r"SEVENTH|EIGHTH|NINTH|TENTH|TOP)\s+\d"
+    )
+    # Side marker (R/L or RIGHT/LEFT) sitting immediately after an expanded
+    # floor position. Compact forms like GFR, GR-R, 1F-L, 10L-L are rewritten
+    # to "{NAME} FLOOR {RIGHT|LEFT}" by the abbreviation normalisation stage
+    # before the parser runs, so we only recognise the expanded form here.
+    expanded_floor_side = (
+        r"\b(?:GROUND|FIRST|SECOND|THIRD|FOURTH|FIFTH|SIXTH|SEVENTH|"
+        r"EIGHTH|NINTH|TENTH)\s+FLOOR\s+(?:([LR])|(LEFT|RIGHT))\b"
     )
 
     # Core token patterns (RE2-compatible; avoid lookbehind)
@@ -226,6 +239,25 @@ def _parse_out_flat_position_and_letter():
                 ''
             ) = 'LOWER FLOOR'
                 THEN 'LOWER FLOOR'
+            WHEN NULLIF(
+                regexp_extract(
+                    i.clean_full_address,
+                    '{leading_bare_floor_position}',
+                    1
+                ),
+                ''
+            ) IS NOT NULL
+                THEN CONCAT(
+                    NULLIF(
+                        regexp_extract(
+                            i.clean_full_address,
+                            '{leading_bare_floor_position}',
+                            1
+                        ),
+                        ''
+                    ),
+                    ' FLOOR'
+                )
             ELSE NULLIF(
                 regexp_extract(i.clean_full_address, '{floor_positions}', 1),
                 ''
@@ -252,6 +284,18 @@ def _parse_out_flat_position_and_letter():
                 regexp_extract(i.clean_full_address, '{block_letter}', 1),
                 ''
             ),
+            NULLIF(
+                regexp_extract(i.clean_full_address, '{expanded_floor_side}', 1),
+                ''
+            ),
+            CASE NULLIF(
+                regexp_extract(i.clean_full_address, '{expanded_floor_side}', 2),
+                ''
+            )
+                WHEN 'LEFT' THEN 'L'
+                WHEN 'RIGHT' THEN 'R'
+                ELSE NULL
+            END,
             NULLIF(
                 regexp_extract(i.clean_full_address, '{leading_num_letter}', 2),
                 ''

--- a/uk_address_matcher/data/address_abbreviations.json
+++ b/uk_address_matcher/data/address_abbreviations.json
@@ -92,7 +92,7 @@
 
   { "token": "EXC", "replacement": "EXCLUDING" },
   { "token": "EXCL", "replacement": "EXCLUDING" },
-  
+
   { "token": "LGND", "replacement": "LOWER GROUND"},
   { "token": "UGND", "replacement": "UPPER GROUND"},
 


### PR DESCRIPTION
- XFR -> X FLOOR
- XF/L -> X FLOOR LEFT
- XF/R -> X FLOOR RIGHT

This covers very few addresses in typically Scotland addresses, but it's an easy tweak to make to improve the number of matches we are able to identify.

It can prove problematic in situations such as this:
- **match_reason (new)**: `splink: probabilistic match`
- **old_outcome**: `unmatched`
- **messy clean_full_address (new)**: `SECOND FLOOR 30 MARISCHAL STREET PETERHEAD`
- **messy clean_full_address (old)**: `2FR 30 MARISCHAL STREET PETERHEAD`
- **messy original**: `2fr, 30, marischal street, peterhead`
- **resolved canonical addresses (matched)**:
    - `30C MARISCHAL STREET PETERHEAD`
    - `SECOND SECOND FLOOR LEFT 30 MARISCHAL STREET PETERHEAD`
    - `SECOND 30C MARISCHAL STREET PETERHEAD`
    - `SECOND FLOOR LEFT 30 MARISCHAL STREET PETERHEAD`
- **label canonical addresses (truth, ukam_label)**:
    - `SECOND FLOOR RIGHT 30 MARISCHAL STREET PETERHEAD`
    - `SECOND 30D MARISCHAL STREET PETERHEAD`
    - `30D MARISCHAL STREET PETERHEAD`
    - `SECOND SECOND FLOOR RIGHT 30 MARISCHAL STREET PETERHEAD`